### PR TITLE
Solving the exposure of window.outstreamPlayer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,6 @@
     "env":{
         "es6":true,
         "node": true,
-        "browser": true,
-        "jest/globals": true
+        "browser": true
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 coverage/
+.idea

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Prebid.js requires an outstream renderer URL in *renderer.url* object and outstr
 renderer: {
     url: 'bundle.js',   // URL of the renderer
     render: function (bid) {
-        try {
-            setTimeout( ()=>{
+        bid.renderer.push(function() {
+            try {
                 // Object to configure the behaviour of outstream renderer from HTML page.
                 var obj = {
                     width: 640,
@@ -38,13 +38,12 @@ renderer: {
                 }
                 // Call to Global object of renderer.
                 // Takes bid, element ID and configuration object as parameters
-                outstreamPlayer(bid, 'video1', obj);
-            }, 3000)
-            
-        } catch (e) {
-            console.error(e);
-            console.error("Error in ad rendering!");
-        }
+                window.outstreamPlayer.player(bid, 'video1', obj);
+            } catch (e) {
+                console.error(e);
+                console.error("Error in ad rendering!");
+            }
+        })
     }
 }       
 ```

--- a/build-utils/webpack.common.js
+++ b/build-utils/webpack.common.js
@@ -44,7 +44,9 @@ module.exports = {
     output: {
         path: path.resolve(__dirname, '../', 'dist'),
         publicPath: '/',
-        filename: 'bundle.js'
+        filename: 'ocm-renderer.js',
+        library: 'outstreamPlayer',
+        libraryTarget: 'var'
     },
     devServer: {
         contentBase: './dist'

--- a/build-utils/webpack.common.js
+++ b/build-utils/webpack.common.js
@@ -44,7 +44,7 @@ module.exports = {
     output: {
         path: path.resolve(__dirname, '../', 'dist'),
         publicPath: '/',
-        filename: 'ocm-renderer.js',
+        filename: 'bundle.js',
         library: 'outstreamPlayer',
         libraryTarget: 'var'
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6460,9 +6460,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "internal-ip": {
@@ -8891,9 +8891,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-int64": {
@@ -10641,12 +10641,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/src/index.html
+++ b/src/index.html
@@ -29,42 +29,45 @@
     <!-- Prebid setup -->
     <script>
 
-        var pbjs = pbjs || {}; 
-        pbjs.que = pbjs.que || [];  
+        var pbjs = pbjs || {};
+        pbjs.que = pbjs.que || [];
         var videoAdUnit = [
             {
-                code: 'video1', 
+                code: 'video1',
                 mediaTypes: {
                     video: {
-                        playerSize: [640, 480], 
+                        playerSize: [640, 480],
                         context: 'outstream'
-                    } 
-                }, 
+                    }
+                },
                 renderer: {
                     url: 'bundle.js',
                     render: function (bid) {
-                        var config = {
-                            width: 640,
-                            height: 480,
-                            vastTimeout: 5000,
-                            maxAllowedVastTagRedirects: 3,
-                            allowVpaid: false,
-                            autoPlay: true,
-                            preload: true,
-                            mute: true,
-                            adText: 'This is sample adtext.'
-                        };
-                        setTimeout( () => {
-                            try{
-                                window.player = outstreamPlayer(bid, 'video1', config);
-                            }catch(e){
+                        bid.renderer.push(function () {
+                            var config = {
+                                width: 640,
+                                height: 480,
+                                vastTimeout: 5000,
+                                maxAllowedVastTagRedirects: 3,
+                                allowVpaid: false,
+                                autoPlay: true,
+                                preload: true,
+                                mute: true,
+                                adText: 'This is sample adtext.'
+                            };
+
+                            try {
+                                // Using outstreamPlayer in production, the proper player path is window.outstreamPlayer.player
+                                // The below is only working for this test's purposes
+                                window.outstreamPlayer.player.player(bid, 'video1', config);
+                            } catch (e) {
                                 console.error(e);
                                 console.error("Error in ad rendering!");
                             }
-                        }, 3000);
+                        })
                     }
                 },
-                bids: [  
+                bids: [
                     { // requests bids from PubMatic partner
                         bidder: 'pubmatic',
                         params: {
@@ -81,18 +84,18 @@
                             }
                         }
                     }
-                ] 
+                ]
             }
-        ]; 
+        ];
 
         pbjs.que.push(function() {
-            pbjs.addAdUnits(videoAdUnit); 
+            pbjs.addAdUnits(videoAdUnit);
             pbjs.setConfig({
-                debug: true, 
+                debug: true,
                 cache: {
                     url: 'https://prebid.adnxs.com/pbc/v1/cache'
-                } 
-            }); 
+                }
+            });
             pbjs.requestBids({
                 timeout: 1000,
                 bidsBackHandler: function(bids) {
@@ -315,7 +318,7 @@
             </div>
             </div>
 
-            
+
 
         </div>
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,9 @@ import OutstreamPlayer from './OutstreamPlayer';
 import logger from './Logger';
 
 // eslint-disable-next-line no-unused-vars
-window.outstreamPlayer = window.outstreamPlayer || ( (bid, elementId, config) =>  {
+var player = window.outstreamPlayer || ( (bid, elementId, config) =>  {
     logger.log("Inside window.outstreamPlayer.");
     return new OutstreamPlayer(bid, elementId, config);
 });
+
+export { player };


### PR DESCRIPTION
This effectively solves https://github.com/prebid/prebid-outstream/issues/5

Maybe there might be a more graceful way to do this.

The weirdest part is that in the dev env, the player function is found under
```
window.outstreamPlayer.player.player
```
while in production, it is accessible through
```
window.outstreamPlayer.player
```

Could definitely use some help on this one.

