### PR TITLE
Fix: Converting circular structure to JSON error

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -16,7 +16,7 @@ class Utils {
     }
 
     getOffset(element) {
-        logger.debug("Inside Utils.getOffset for element: " + JSON.stringify(element));
+        logger.debug("Inside Utils.getOffset for element");
         var scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
         var scrollTop = window.pageYOffset || document.documentElement.scrollTop;
         // Check if element is not present


### PR DESCRIPTION
Getting the following error when there is a circular structure in the `element` object. 
```
Uncaught TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Hs'
    |     property 'stateNode' -> object with constructor 'HTMLDivElement'
    --- property '__reactInternalInstance$dukfb7srxhn' closes the circle
    at JSON.stringify (<anonymous>)
    at eval (eval at value (bundle.js:formatted:1), <anonymous>:1:6)
    at e.value (bundle.js:formatted:5542)
    at e.value (bundle.js:formatted:5567)
    at e.value (bundle.js:formatted:5844)
    at new e (bundle.js:formatted:5836)
    at Object.window.mnet.mediaNetoutstreamPlayer (bundle.js:formatted:5910)
    at pb.js?domain=tasteofcountry.com&v=1b3986bff5fce6d71f2233c12430887641225be5&mver=40&gver=3:formatted:11907
    at e (bundle.js:formatted:5904)
    at bundle.js:formatted:5914
```
Steps to reproduce
1. Go to (Using US proxy) https://tasteofcountry.com/eric-church-katherine-blasingame-wife-marriage-love-story/?frpvid=2030&frbid=2&pbjs_debug=1
2. Wait for https://prebid.media.net/video/bundle.js   (This is prebid-outstream hosted at media.net domain)
3. Add a breakpoint at line number 5542 (On Formatted js)
4. on console type: JSON.stringify(e).  you will get the above error. 

I am attaching a screenshot for your reference. 
![error](https://user-images.githubusercontent.com/67756716/110209204-24ffff00-7eb1-11eb-9ffe-6de47c5d56b5.png)

