### PR TITLE
Add player override feature. Update videojs implementation. Add JWPlayer implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 coverage/
 docker-compose.override.yml
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 coverage/
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ User can provide some configurations to the outstream player on runtime while ca
 + `preload` - Sets the preload parameter on video tag. (Default: true)
 + `mute` - Set this parameter to true to have the video muted by default. (Default: true)
 + `adText` - To set the custom text when an in-stream ad plays. (Default: '' - an empty string)
-+ `playerConfigOverrides` - To set overrides on the player config. This is to hook into events and/or set styles needed. This is a deep copy, and will only override values set in object. It will not unset already defined values.
++ `playerOverrides` - To set overrides on the player config. This is to hook into events and/or set styles needed. This is a deep copy, and will only override values set in object. It will not unset already defined values.
 
-*Note 1:* Providig these parameters is completely optional, in which case we will use there default values.
+*Note 1:* Providing these parameters is completely optional, in which case we will use there default values.
 
 *Note 2:* While providing custom values to above parameters, please make sure to provide these values with proper datatype otherwise default values will be used.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ renderer: {
                     autoPlay: true,
                     preload: true,
                     mute: false,
-                    adText: 'This is sample adtext.'
+                    adText: 'This is sample adtext.',
+                    playerConfigOverrides: {}
                 }
                 // Call to Global object of renderer.
                 // Takes bid, element ID and configuration object as parameters
@@ -83,6 +84,7 @@ User can provide some configurations to the outstream player on runtime while ca
 + `preload` - Sets the preload parameter on video tag. (Default: true)
 + `mute` - Set this parameter to true to have the video muted by default. (Default: true)
 + `adText` - To set the custom text when an in-stream ad plays. (Default: '' - an empty string)
++ `playerConfigOverrides` - To set overrides on the player config. This is to hook into events and/or set styles needed. This is a deep copy, and will only override values set in object. It will not unset already defined values.
 
 *Note 1:* Providig these parameters is completely optional, in which case we will use there default values.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The user needs to provide his selected player in **SELECTED_PLAYER** environment
 **Supported Players**
 + `FLUID_PLAYER` - Fluid player
 + `VIDEO_JS` - Video JS
++ `JWPLAYER` - JWPlayer
 
 *Note 1:* At present, we only fully support Fluid player as Video JS player is not fully implemented. We are looking for your help in adding support to other major players.
 

--- a/build-utils/webpack.common.js
+++ b/build-utils/webpack.common.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const webpack = require('webpack');
 
 module.exports = {
     entry: './src/index.js',
@@ -38,9 +37,6 @@ module.exports = {
             title: 'Hello Webpack bundled JavaScript Project',
             template: './src/index.html'
         }),
-        new webpack.optimize.LimitChunkCountPlugin({
-            maxChunks: 1
-        })
     ],
     output: {
         path: path.resolve(__dirname, '../', 'dist'),

--- a/build-utils/webpack.common.js
+++ b/build-utils/webpack.common.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
     entry: './src/index.js',
@@ -29,9 +30,6 @@ module.exports = {
         ]
     },
     resolve: {
-        alias: {
-            '~' : path.resolve(__dirname, '../', 'node_modules')
-        },
         extensions: ['*', '.js']
     },
     plugins: [
@@ -39,14 +37,14 @@ module.exports = {
         new HtmlWebpackPlugin({
             title: 'Hello Webpack bundled JavaScript Project',
             template: './src/index.html'
+        }),
+        new webpack.optimize.LimitChunkCountPlugin({
+            maxChunks: 1
         })
     ],
     output: {
         path: path.resolve(__dirname, '../', 'dist'),
         publicPath: '/',
         filename: 'bundle.js'
-    },
-    devServer: {
-        contentBase: './dist'
     },
 };

--- a/build-utils/webpack.dev.js
+++ b/build-utils/webpack.dev.js
@@ -10,4 +10,7 @@ module.exports = {
             path: './.env.development',
         })
     ],
+    devServer: {
+        contentBase: './dist'
+    },
 };

--- a/build-utils/webpack.prod.js
+++ b/build-utils/webpack.prod.js
@@ -9,7 +9,4 @@ module.exports = {
             path: './.env.production',
         })
     ],
-    output: {
-        filename: 'prebid-video-renderer.js',
-    }
 };

--- a/build-utils/webpack.prod.js
+++ b/build-utils/webpack.prod.js
@@ -9,4 +9,7 @@ module.exports = {
             path: './.env.production',
         })
     ],
+    output: {
+        filename: 'prebid-video-renderer.js',
+    }
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+volumes:
+    deps:
+
+services:
+    outstream:
+        image: node:14.15.4
+        volumes:
+            - .:/usr/src/app
+            - deps:/usr/src/app/node_modules
+        working_dir: /usr/src/app
+        command: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -989,7 +989,6 @@
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
       "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1559,6 +1558,13 @@
         }
       }
     },
+    "@prebid/videojs-vast": {
+      "version": "git+https://github.com/prebid/videojs-mailonline-plugin.git#50df36f02ef33aa6a6d73f509a0a357e05c878c3",
+      "from": "git+https://github.com/prebid/videojs-mailonline-plugin.git#v1.3.18",
+      "requires": {
+        "vpaid-html5-client": "git://github.com/MailOnline/VPAIDHTML5Client.git"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -1807,6 +1813,66 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
+    "@videojs/http-streaming": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-2.6.4.tgz",
+      "integrity": "sha512-sFVE0MVXhawAkET8EgiUSMvDDv6u3uGidtO0BvNXG0/qKWlze/zEzhvLsyPU4HmLFRnffKeHK5RE2XpO5vHY8Q==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.0",
+        "aes-decrypter": "3.1.2",
+        "global": "^4.4.0",
+        "m3u8-parser": "4.5.2",
+        "mpd-parser": "0.15.4",
+        "mux.js": "5.10.0",
+        "video.js": "^6 || ^7"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@videojs/vhs-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.0.tgz",
+      "integrity": "sha512-HPgiaVB8/g7DooYFQ20uTinq4eNRHmIXGHHttK/Xwyvn19MfIpg9BfMNr9ywCvgHh0IUGrxt6P8AcmMO4xvxIA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "url-toolkit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.1.tgz",
+          "integrity": "sha512-8+DzgrtDZYZGhHaAop5WGVghMdCfOLGbhcArsJD0qDll71FXa7EeKxi2hilPIscn2nwMz4PRjML32Sz4JTN0Xw=="
+        }
+      }
+    },
+    "@videojs/xhr": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.5.1.tgz",
+      "integrity": "sha512-wV9nGESHseSK+S9ePEru2+OJZ1jq/ZbbzniGQ4weAmTIepuBMSYPx5zrxxQA0E786T5ykpO8ts+LayV+3/oI2w==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "global": "~4.4.0",
+        "is-function": "^1.0.1"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -2037,6 +2103,27 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
+    },
+    "aes-decrypter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.2.tgz",
+      "integrity": "sha512-42nRwfQuPRj9R1zqZBdoxnaAmnIFyDi0MNyTVhjdFOd8fifXKKRfwIHIZ6AMn1or4x5WONzjwRTbTWcsIQ0O4A==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.0",
+        "global": "^4.4.0",
+        "pkcs7": "^1.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
     },
     "ajv": {
       "version": "6.12.3",
@@ -2977,6 +3064,14 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chainsaw": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.0.9.tgz",
+      "integrity": "sha1-EaBRAtHEx4W20EFdM21aOhYSkT4=",
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -4894,6 +4989,11 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6004,6 +6104,14 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hashish": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz",
+      "integrity": "sha1-bWC8b/r3Ebav1g5CbQd5iAFOZVQ=",
+      "requires": {
+        "traverse": ">=0.2.4"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -6454,6 +6562,11 @@
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
+    "individual": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
+      "integrity": "sha1-gzsJfa0jKU52EXqY+zjg2a1hu5c="
+    },
     "infer-owner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -6663,6 +6776,11 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
+    },
+    "is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -8390,6 +8508,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "keycode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -8574,6 +8697,34 @@
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
+      }
+    },
+    "m3u8-parser": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.5.2.tgz",
+      "integrity": "sha512-sN/lu3TiRxmG2RFjZxo5c0/7Dr4RrEztl43jXrWwj5gFZ7vfa2iIxGfiPx485dm5QCazaIcKk+vNkUso8Aq0Ag==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.0",
+        "global": "^4.4.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -8837,6 +8988,32 @@
         "run-queue": "^1.0.3"
       }
     },
+    "mpd-parser": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.15.4.tgz",
+      "integrity": "sha512-YcOclxKc5gnT87UQYwRoPJpWOFvQORwN+bXYmTWCJ4U2pCSS7jjtPrIhoOLHFAyekj48CHTX4hjGBV/VSNsUsg==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.0",
+        "global": "^4.4.0",
+        "xmldom": "^0.4.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "xmldom": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
+          "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA=="
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8858,6 +9035,14 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
+    },
+    "mux.js": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-5.10.0.tgz",
+      "integrity": "sha512-kLzvYsHYBwNa+ckkmpxWV3eImwntJbrwd1KbN4WR0hLe+dK/KB82aCuC0fQzAI2hkjYszdlSGsAWFgYdiFBUuA==",
+      "requires": {
+        "@babel/runtime": "^7.11.2"
+      }
     },
     "nan": {
       "version": "2.14.2",
@@ -9613,6 +9798,14 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
+    "pkcs7": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
+      "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5"
+      }
+    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -10175,8 +10368,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -10255,6 +10447,14 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
+    },
+    "remove": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/remove/-/remove-0.1.5.tgz",
+      "integrity": "sha1-CV/9gn1lyfQa2X0z5BanWBEHmVU=",
+      "requires": {
+        "seq": ">= 0.3.5"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -10463,6 +10663,23 @@
         "inherits": "^2.0.1"
       }
     },
+    "rollup-plugin-replace": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",
+      "integrity": "sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==",
+      "requires": {
+        "magic-string": "^0.25.2",
+        "rollup-pluginutils": "^2.6.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "requires": {
+        "estree-walker": "^0.6.1"
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -10478,10 +10695,26 @@
         "aproba": "^1.1.1"
       }
     },
+    "rust-result": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
+      "integrity": "sha1-NMdbLm3Dn+WHXlveyFteD5FTb3I=",
+      "requires": {
+        "individual": "^2.0.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-json-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
+      "integrity": "sha1-fA9XjPzNEtM6ccDgVBPi7KFx6qw=",
+      "requires": {
+        "rust-result": "^1.0.0"
+      }
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -10728,6 +10961,15 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
+      }
+    },
+    "seq": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/seq/-/seq-0.3.5.tgz",
+      "integrity": "sha1-rgKvOkJHk9jMvyEtaRdODFTf/jg=",
+      "requires": {
+        "chainsaw": ">=0.0.7 <0.1",
+        "hashish": ">=0.0.2 <0.1"
       }
     },
     "serialize-javascript": {
@@ -11133,6 +11375,11 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -11819,6 +12066,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+    },
     "tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -12225,6 +12477,44 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "video.js": {
+      "version": "7.11.8",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.11.8.tgz",
+      "integrity": "sha512-iQmNYB+pdgu8b45Za1AKSa5J7uDyHIqfJy+picw4voKfjErXK/BEvs+A3f99Ck7SCZU4cmMmX/s17AwaaNs+1w==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@videojs/http-streaming": "2.6.4",
+        "@videojs/xhr": "2.5.1",
+        "global": "4.3.2",
+        "keycode": "^2.2.0",
+        "remove": "^0.1.5",
+        "rollup-plugin-replace": "^2.2.0",
+        "safe-json-parse": "4.0.0",
+        "videojs-font": "3.2.0",
+        "videojs-vtt.js": "^0.15.2"
+      },
+      "dependencies": {
+        "global": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+          "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
+          }
+        },
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+        }
+      }
+    },
+    "videojs-font": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
+      "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
+    },
     "videojs-vtt.js": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.2.tgz",
@@ -12238,6 +12528,10 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "vpaid-html5-client": {
+      "version": "git://github.com/MailOnline/VPAIDHTML5Client.git#74908bf2d4ac03e33674afdd9515111195a2b0f1",
+      "from": "git://github.com/MailOnline/VPAIDHTML5Client.git"
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2632,6 +2632,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5277,6 +5287,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filesize": {
       "version": "3.6.1",
@@ -8515,6 +8532,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -8836,6 +8858,13 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12371,7 +12400,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -13093,7 +13126,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "webpack-visualizer-plugin": "^0.1.11"
   },
   "dependencies": {
+    "@prebid/videojs-vast": "git+https://github.com/prebid/videojs-mailonline-plugin.git#v1.3.18",
     "fluid-player": "^3.0.4",
-    "lodash.merge": "^4.6.2"
+    "lodash.merge": "^4.6.2",
+    "video.js": "^7.11.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "webpack-visualizer-plugin": "^0.1.11"
   },
   "dependencies": {
-    "fluid-player": "^3.0.4"
+    "fluid-player": "^3.0.4",
+    "lodash.merge": "^4.6.2"
   }
 }

--- a/src/GenericConfiguration.js
+++ b/src/GenericConfiguration.js
@@ -34,5 +34,10 @@ export default class GenericConfiguration {
         this.adText =  ( typeof config.adText === 'string' ) ?
             config.adText :
             '';
+
+        // Object type
+        this.playerConfigOverrides = ( typeof config.playerConfigOverrides === 'object') ?
+            config.playerConfigOverrides :
+            {};
     }
 }

--- a/src/GenericConfiguration.js
+++ b/src/GenericConfiguration.js
@@ -36,8 +36,8 @@ export default class GenericConfiguration {
             '';
 
         // Object type
-        this.playerConfigOverrides = ( typeof config.playerConfigOverrides === 'object') ?
-            config.playerConfigOverrides :
+        this.playerOverrides = ( typeof config.playerOverrides === 'object') ?
+            config.playerOverrides :
             {};
     }
 }

--- a/src/PlayerFactory.js
+++ b/src/PlayerFactory.js
@@ -11,6 +11,12 @@ logger.info("Conditional import of fluid player as environment variable process.
 import FluidPlayer from './players/fluid-player/FluidPlayer';
 // #endif
 
+// #if process.env.SELECTED_PLAYER === 'JWPLAYER'
+logger.info("Conditional import of jwplayer as environment variable process.env.SELECTED_PLAYER value is: " + process.env.SELECTED_PLAYER);
+import JWPlayer from './players/jwplayer/JWPlayer';
+// #endif
+
+
 // Factory pattern.
 // Returns the actual player object.
 export default class PlayerFactory{
@@ -24,6 +30,9 @@ export default class PlayerFactory{
         case 'VIDEO_JS':
             logger.log("VIDEO_JS selected.");
             return new VideoJs();
+        case 'JWPLAYER':
+            logger.log("JWPLAYER selected.");
+            return new JWPlayer();
         default:
             logger.log("Default player selected.");
             return new FluidPlayer();

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -16,7 +16,7 @@ class Utils {
     }
 
     getOffset(element) {
-        logger.debug("Inside Utils.getOffset for element: " + JSON.stringify(element));
+        logger.debug("Inside Utils.getOffset for element: " + (element && element.id));
         var scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
         var scrollTop = window.pageYOffset || document.documentElement.scrollTop;
         // Check if element is not present

--- a/src/players/fluid-player/FluidPlayer.js
+++ b/src/players/fluid-player/FluidPlayer.js
@@ -1,7 +1,6 @@
 import GenericPlayer from '../GenericPlayer';
 import fluidPlayer from 'fluid-player';
 import FluidPlayerConfig from './FluidPlayerConfig';
-import '~/fluid-player/src/css/fluidplayer.css';
 import logger from '../../Logger';
 import utils from '../../Utils';
 import './fluidPlayer.css';

--- a/src/players/fluid-player/FluidPlayerConfig.js
+++ b/src/players/fluid-player/FluidPlayerConfig.js
@@ -1,4 +1,5 @@
 import logger from '../../Logger';
+import merge from 'lodash.merge'
 
 export default class FluidPlayerConfig{
     constructor(bid, elementId, genericConfiguration){
@@ -117,6 +118,9 @@ export default class FluidPlayerConfig{
             showCardBoardView:      false,
             showCardBoardJoystick:  false
         };
+
+        // Allow player config overrides
+        merge(this, genericConfiguration.playerConfigOverrides);
 
         let ad;
         if( !(bid.ad === undefined || bid.ad === null) ){

--- a/src/players/fluid-player/FluidPlayerConfig.js
+++ b/src/players/fluid-player/FluidPlayerConfig.js
@@ -59,6 +59,9 @@ export default class FluidPlayerConfig{
                 autoHideTimeout:    5, // Default 3
                 animated:           true // Default true
             },
+            contextMenu: {
+                controls: false,
+            },
             captions: {
                 play:               'Play',
                 pause:              'Pause',
@@ -77,13 +80,13 @@ export default class FluidPlayerConfig{
                 volume:             false, // Default true
                 quality:            false, // Default true
                 speed:              false, // Default true
-                theatre:            false // Default true
+                theatre:            false  // Default true
             },
             allowTheatre:           true, // Default true
             theatreSettings: {
                 width:              '100%', // Default '100%'
-                height:             '60%', // Default '60%'
-                marginTop:          10, // Default 0
+                height:             '60%',  // Default '60%'
+                marginTop:          10,     // Default 0
                 horizontalAlign:    'center' // 'left', 'right' or 'center'
             },
             playbackRateEnabled:    false, // Default false

--- a/src/players/fluid-player/FluidPlayerConfig.js
+++ b/src/players/fluid-player/FluidPlayerConfig.js
@@ -120,7 +120,7 @@ export default class FluidPlayerConfig{
         };
 
         // Allow player config overrides
-        merge(this, genericConfiguration.playerConfigOverrides);
+        merge(this, genericConfiguration.playerOverrides);
 
         let ad;
         if( !(bid.ad === undefined || bid.ad === null) ){

--- a/src/players/fluid-player/fluidPlayer.css
+++ b/src/players/fluid-player/fluidPlayer.css
@@ -1,3 +1,1321 @@
 .fluid_ad_playing{
     white-space: break-spaces;
 }
+
+.fluid_video_wrapper {
+    animation: none;
+    animation-delay: 0;
+    animation-direction: normal;
+    animation-duration: 0;
+    animation-fill-mode: none;
+    animation-iteration-count: 1;
+    animation-name: none;
+    animation-play-state: running;
+    animation-timing-function: ease;
+    backface-visibility: visible;
+    background: 0;
+    background-attachment: scroll;
+    background-clip: border-box;
+    background-color: transparent;
+    background-image: none;
+    background-origin: padding-box;
+    background-position: 0 0;
+    background-position-x: 0;
+    background-position-y: 0;
+    background-repeat: repeat;
+    background-size: auto auto;
+    border: 0;
+    border-style: none;
+    border-width: medium;
+    border-color: inherit;
+    border-bottom: 0;
+    border-bottom-color: inherit;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-style: none;
+    border-bottom-width: medium;
+    border-collapse: separate;
+    border-image: none;
+    border-left: 0;
+    border-left-color: inherit;
+    border-left-style: none;
+    border-left-width: medium;
+    border-radius: 0;
+    border-right: 0;
+    border-right-color: inherit;
+    border-right-style: none;
+    border-right-width: medium;
+    border-spacing: 0;
+    border-top: 0;
+    border-top-color: inherit;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-top-style: none;
+    border-top-width: medium;
+    bottom: auto;
+    box-shadow: none;
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+    caption-side: top;
+    clear: none;
+    clip: auto;
+    color: inherit;
+    columns: auto;
+    column-count: auto;
+    column-fill: balance;
+    column-gap: normal;
+    column-rule: medium none currentColor;
+    column-rule-color: currentColor;
+    column-rule-style: none;
+    column-rule-width: none;
+    column-span: 1;
+    column-width: auto;
+    content: normal;
+    counter-increment: none;
+    counter-reset: none;
+    cursor: auto;
+    direction: ltr;
+    display: inline;
+    empty-cells: show;
+    float: none;
+    font: normal;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-size: medium;
+    font-style: normal;
+    font-variant: normal;
+    font-weight: normal;
+    height: auto;
+    hyphens: none;
+    left: auto;
+    letter-spacing: normal;
+    line-height: normal;
+    list-style: none;
+    list-style-image: none;
+    list-style-position: outside;
+    list-style-type: disc;
+    margin: 0;
+    margin-bottom: 0;
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 0;
+    max-height: none;
+    max-width: none;
+    min-height: 0;
+    min-width: 0;
+    opacity: 1;
+    orphans: 0;
+    outline: 0;
+    outline-color: invert;
+    outline-style: none;
+    outline-width: medium;
+    overflow: visible;
+    overflow-x: visible;
+    overflow-y: visible;
+    padding: 0;
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    page-break-after: auto;
+    page-break-before: auto;
+    page-break-inside: auto;
+    perspective: none;
+    perspective-origin: 50% 50%;
+    position: static;
+    /* May need to alter quotes for different locales (e.g fr) */
+    quotes: '\201C' '\201D' '\2018' '\2019';
+    right: auto;
+    tab-size: 8;
+    table-layout: auto;
+    text-align: inherit;
+    text-align-last: auto;
+    text-decoration: none;
+    text-decoration-color: inherit;
+    text-decoration-line: none;
+    text-decoration-style: solid;
+    text-indent: 0;
+    text-shadow: none;
+    text-transform: none;
+    top: auto;
+    transform: none;
+    transform-style: flat;
+    transition: none;
+    transition-delay: 0s;
+    transition-duration: 0s;
+    transition-property: none;
+    transition-timing-function: ease;
+    unicode-bidi: normal;
+    vertical-align: baseline;
+    visibility: visible;
+    white-space: normal;
+    widows: 0;
+    width: auto;
+    word-spacing: normal;
+    z-index: auto;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.fluid_video_wrapper canvas {
+    pointer-events: none;
+}
+
+.fluid_video_wrapper,
+.fluid_video_wrapper * {
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+}
+
+.fluid_video_wrapper:after, .fluid_video_wrapper:before {
+    content: none;
+}
+
+.fluid_video_wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.fluid_video_wrapper video {
+    position: relative;
+    background-color: #000000;
+    display: block;
+}
+
+.fluid_video_wrapper .vast_video_loading {
+    display: table;
+    text-align: center;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    pointer-events: auto;
+    z-index: 1;
+}
+
+.fluid_video_wrapper .vast_video_loading:before {
+    background-image: url("data:image/svg+xml,%3Csvg class='lds-eclipse' width='200' height='200' style='background:0 0' preserveAspectRatio='xMidYMid' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E %3Cpath d='M68.095 59.578A20 20 0 0031.14 44.27a22 20-67.5 0136.955 15.308' fill='%23fff'%3E %3CanimateTransform attributeName='transform' begin='0s' calcMode='linear' dur='0.8s' keyTimes='0;1' repeatCount='indefinite' type='rotate' values='0 50 51;360 50 51'/%3E %3C/path%3E %3C/svg%3E");
+    background-position: center, center;
+    background-repeat: no-repeat, repeat;
+    background-color: rgba(0, 0, 0, 0.2);
+    content: '';
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+}
+
+.skip_button {
+    position: absolute;
+    bottom: 50px;
+    right: 0;
+    background-color: rgba(0, 0, 0, 0.7);
+    padding: 13px 21px 13px 21px;
+}
+
+.skip_button, .skip_button a {
+    color: #ffffff;
+    text-decoration: none;
+    cursor: pointer;
+    z-index: 10;
+    font-size: 13px;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-weight: normal;
+    white-space: nowrap;
+    text-align: start;
+}
+
+.skip_button a span.skip_button_icon {
+    display: inline-block;
+    text-align: left;
+    width: 21px;
+    position: relative;
+    bottom: 20px;
+}
+
+.skip_button a span.skip_button_icon:before {
+    background: url("data:image/svg+xml,%3Csvg xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg' width='388.75' height='96' version='1.1' viewBox='0 0 388.75 96' id='svg63'%3E %3Cpath id='path4087' d='m 347.64062,35.959 a 6.9826789,6.9826789 0 0 0 6.98438,-6.984375 6.9826789,6.9826789 0 0 0 -6.98438,-6.982422 6.9826789,6.9826789 0 0 0 -6.98242,6.982422 6.9826789,6.9826789 0 0 0 6.98242,6.984375 z m 0,-2.476562 a 4.5078053,4.5078053 0 0 1 -4.50781,-4.507813 4.5078053,4.5078053 0 0 1 4.50781,-4.507812 4.5078053,4.5078053 0 0 1 4.50781,4.507812 4.5078053,4.5078053 0 0 1 -4.50781,4.507813 z' style='fill:%23ffffff;fill-opacity:1;stroke-width:1.70873225' /%3E %3Cpath style='fill:%23ffffff;fill-opacity:1;stroke-width:1.00886583' d='M 273.55469,22 C 272.69375,22 272,22.693749 272,23.554688 V 34.445312 C 272,35.306251 272.69375,36 273.55469,36 h 10.89062 C 285.30625,36 286,35.306251 286,34.445312 V 23.554688 C 286,22.693749 285.30625,22 284.44531,22 Z m 3.61133,4.541016 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z m 4.75,0 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z' id='rect7816' /%3E %3Cg transform='translate(-3702,106)' id='g44'%3E %3CclipPath id='q' style='clip-rule:evenodd'%3E %3Cpath d='m 3702,-106 h 272 v 96 h -272 z' id='path6' style='fill:%23ffffff'/%3E %3C/clipPath%3E %3Cg clip-path='url(%23q)' id='g42'%3E %3Cuse transform='translate(3757,-86)' xlink:href='%23o' id='use9' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3757,-48)' xlink:href='%23i' id='use11' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3830,-84)' xlink:href='%23h' id='use13' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-86)' xlink:href='%23g' id='use15' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-48)' xlink:href='%23f' id='use17' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-46)' xlink:href='%23e' id='use19' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3831,-46)' xlink:href='%23d' id='use21' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3865,-44)' xlink:href='%23c' id='use23' style='fill:%23f2c94c' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-84)' xlink:href='%23b' id='use25' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3866,-83)' xlink:href='%23a' id='use27' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-47)' xlink:href='%23n' id='use29' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cmask id='p'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23m' id='use31' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/mask%3E %3Cg mask='url(%23p)' id='g36'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23l' id='use34' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3Cuse transform='translate(3904,-85)' xlink:href='%23k' id='use38' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-85)' xlink:href='%23j' id='use40' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3C/g%3E %3Cdefs id='defs61'%3E %3Cpath id='o' d='m 0,5.5924 v 5.8152 H 3.7778 L 8.5,16.2537 V 0.7467 L 3.7778,5.5928 H 0 Z M 12.75,8.5 c 0,-1.7155 -0.9633,-3.1887 -2.3611,-3.9059 v 7.8021 C 11.7867,11.6887 12.75,10.2155 12.75,8.5 Z M 10.3889,0 v 1.9966 c 2.7294,0.83352 4.7222,3.431 4.7222,6.5034 0,3.0724 -1.9928,5.6699 -4.7222,6.5034 V 17 C 14.1761,16.118 17,12.6482 17,8.5 17,4.3518 14.1761,0.882 10.3889,0 Z' /%3E %3Cpath id='i' d='m 12.75,8.5 c 0,-1.6717 -0.9633,-3.1072 -2.3611,-3.8061 V 6.7811 L 12.7028,9.095 C 12.7311,8.90611 12.75,8.70778 12.75,8.5 Z m 2.3611,0 c 0,0.88778 -0.1889,1.7189 -0.51,2.4933 l 1.4261,1.4261 C 16.6506,11.2483 17,9.9167 17,8.5 17,4.4578 14.1761,1.0767 10.3889,0.2172 V 2.1628 C 13.1183,2.97502 15.1111,5.5061 15.1111,8.5 Z M 1.1991,0 -3e-4,1.1994 4.4669,5.6666 H -3e-4 v 5.6666 h 3.7778 l 4.7222,4.7223 V 9.6993 l 4.0139,4.0139 c -0.6328,0.4911 -1.3411,0.8784 -2.125,1.1145 v 1.9455 c 1.3033,-0.2927 2.4839,-0.8972 3.485,-1.7094 l 1.9267,1.9361 1.1994,-1.1994 -8.5,-8.5 L 1.1991,-1e-4 Z m 7.3006,0.94444 -1.9739,1.9739 1.9739,1.9739 z' /%3E %3Cpath id='h' d='M 12.444,0 H 1.555 C 0.69166,0 -6e-4,0.7 -6e-4,1.5556 v 10.889 c 0,0.8556 0.69222,1.5556 1.5556,1.5556 h 10.889 c 0.8556,0 1.5556,-0.7 1.5556,-1.5556 V 1.5556 C 13.9996,0.70004 13.2996,0 12.444,0 Z M 6.2218,9.3333 H 5.0551 V 7.7777 H 3.4995 V 9.3333 H 2.3328 V 4.6666 H 3.4995 V 6.611 H 5.0551 V 4.6666 H 6.2218 Z M 7.7774,4.6666 h 3.1111 c 0.4278,0 0.7778,0.35 0.7778,0.77777 v 3.1111 c 0,0.42777 -0.35,0.77777 -0.7778,0.77777 H 7.7774 v -4.6667 z m 1.1667,3.5 h 1.5556 V 5.8333 H 8.9441 Z' /%3E %3Cpath id='g' d='M 0,0 V 17 L 13,8.5 Z' /%3E %3Cpath id='f' d='M 0,17 H 4.3333 V 0 H 0 Z M 8.6667,0 V 17 H 13 V 0 Z' /%3E %3Cpath id='e' d='m 0,11 h 3 v 3 H 5 V 9 H 0 Z M 3,3 H 0 V 5 H 5 V 0 H 3 Z m 6,11 h 2 v -3 h 3 V 9 H 9 Z M 11,3 V 0 H 9 v 5 h 5 V 3 Z' /%3E %3Cpath id='d' d='M 0,12 8.5,6 0,0 Z M 10,0 v 12 h 2 V 0 Z' /%3E %3Cpath id='c' d='M 1.52,4.5 C 1.52,2.961 2.632,1.71 4,1.71 H 7.2 V 0 H 4 C 1.792,0 0,2.016 0,4.5 0,6.984 1.792,9 4,9 H 7.2 V 7.29 H 4 C 2.632,7.29 1.52,6.039 1.52,4.5 Z M 4.8,5.4 h 6.4 V 3.6 H 4.8 Z M 12,0 H 8.8 V 1.71 H 12 c 1.368,0 2.48,1.251 2.48,2.79 0,1.539 -1.112,2.79 -2.48,2.79 H 8.8 V 9 H 12 C 14.208,9 16,6.984 16,4.5 16,2.016 14.208,0 12,0 Z' /%3E %3Cpath id='b' d='M 2,9 H 0 v 5 H 5 V 12 H 2 Z M 0,5 H 2 V 2 H 5 V 0 H 0 Z m 12,7 H 9 v 2 h 5 V 9 H 12 Z M 9,0 v 2 h 3 v 3 h 2 V 0 Z' /%3E %3Cpath id='a' d='M 4.4546,8.7015 1.1137,5.2537 1e-4,6.403 4.4546,11 14,1.1492 12.8864,-1e-4 4.4546,8.7014 Z' /%3E %3Cpath id='n' d='M 12.348,7.686 C 12.3768,7.462 12.3984,7.238 12.3984,7 12.3984,6.762 12.3768,6.538 12.348,6.314 L 13.8664,5.159 C 14.0032,5.054 14.0391,4.865 13.9528,4.711 L 12.5135,2.289 C 12.4272,2.135 12.2329,2.079 12.0745,2.135 l -1.7919,0.7 C 9.90842,2.555 9.50543,2.324 9.0664,2.149 L 8.79294,0.294 C 8.77135,0.126 8.62022,0 8.44031,0 H 5.56171 C 5.38181,0 5.23068,0.126 5.20909,0.294 L 4.93563,2.149 C 4.49665,2.324 4.09365,2.562 3.71943,2.835 l -1.7919,-0.7 C 1.76201,2.072 1.5749,2.135 1.48855,2.289 l -1.4393,2.422 c -0.093553,0.154 -0.050374,0.343 0.086356,0.448 l 1.5184,1.155 C 1.625226,6.538 1.603636,6.769 1.603636,7 c 0,0.231 0.02159,0.462 0.05037,0.686 l -1.5184,1.155 c -0.13673,0.105 -0.17271,0.294 -0.086356,0.448 l 1.4393,2.422 c 0.08635,0.154 0.28066,0.21 0.43898,0.154 l 1.7919,-0.7 c 0.37421,0.28 0.77721,0.511 1.2162,0.686 l 0.27346,1.855 C 5.23068,13.874 5.38181,14 5.56171,14 h 2.8786 c 0.17991,0 0.33104,-0.126 0.35263,-0.294 L 9.0664,11.851 c 0.43898,-0.175 0.84197,-0.413 1.2162,-0.686 l 1.7919,0.7 c 0.1655,0.063 0.3527,0 0.439,-0.154 L 13.9528,9.289 C 14.0391,9.135 14.0032,8.946 13.8664,8.841 Z M 7.0011,9.45 C 5.6122,9.45 4.4824,8.351 4.4824,7 4.4824,5.649 5.6122,4.55 7.0011,4.55 8.39,4.55 9.5198,5.649 9.5198,7 9.5198,8.351 8.39,9.45 7.0011,9.45 Z' /%3E %3Cpath id='m' d='M 0,0 H 16 V 12 H 0 Z' /%3E %3Cpath id='l' d='m 0,0 v -2 h -2 v 2 z m 16,0 h 2 v -2 h -2 z m 0,12 v 2 h 2 V 12 Z M 0,12 h -2 v 2 H 0 Z M 0,2 H 16 V -2 H 0 Z M 14,0 v 12 h 4 V 0 Z m 2,10 H 0 v 4 H 16 Z M 2,12 V 0 h -4 v 12 z' /%3E %3Cpath id='k' d='M 12,5.2941 H 8.5714 V 0 H 3.4285 V 5.2941 H -1e-4 l 6,6.1765 6,-6.1765 z M 0,13.2353 V 15 h 12 v -1.7647 z' /%3E %3Cpath id='j' d='M 9.3333,0 H 4.6666 V 1.5238 H 9.3333 Z M 6.2222,9.9048 H 7.7778 V 5.3334 H 6.2222 Z M 12.4678,4.8686 13.5722,3.7867 C 13.2378,3.39813 12.8722,3.03241 12.4756,2.7124 L 11.3711,3.7943 C 10.1656,2.84953 8.6489,2.2857 7,2.2857 3.1344,2.2857 0,5.3562 0,9.1429 0,12.9295 3.1267,16 7,16 10.8733,16 14,12.9295 14,9.1429 14,7.5277 13.4244,6.0419 12.4678,4.8686 Z M 7,14.4762 C 3.99,14.4762 1.5556,12.0914 1.5556,9.1429 1.5556,6.1943 3.99,3.8096 7,3.8096 c 3.01,0 5.4444,2.3848 5.4444,5.3333 0,2.9485 -2.4344,5.3333 -5.4444,5.3333 z' /%3E %3C/defs%3E %3Cg id='g3989' transform='matrix(0.03107656,0,0,0.03432918,271.52581,57.128037)' style='fill:%23ffffff'%3E %3Cg id='g3979' style='fill:%23ffffff'%3E %3Cpath style='fill:%23ffffff;stroke-width:0.03266241' d='m 273.49023,60.4375 c -1.07158,0 -1.96484,0.958273 -1.96484,2.169922 v 6.61914 c 0,1.216352 0.89727,2.167935 1.96484,2.167969 h 2.87305 c 0.52417,0 1.01765,-0.2246 1.39063,-0.634765 l 1,-1.103516 c 0.19059,-0.211639 0.45448,-0.333984 0.72656,-0.333984 0.27207,0 0.53829,0.122547 0.73047,0.335937 l 0.99804,1.101563 c 0.37212,0.409203 0.86646,0.634765 1.39063,0.634765 h 2.87305 c 1.07158,0 1.96484,-0.95632 1.96484,-2.167969 v -6.61914 c 0,-1.216352 -0.89727,-2.169922 -1.96484,-2.169922 z m 2.4961,3.308594 c 1.08295,0 1.96484,0.973618 1.96484,2.169922 0,1.196303 -0.88185,2.169921 -1.96484,2.169922 -1.08299,0 -1.96485,-0.973619 -1.96485,-2.169922 0,-1.196304 0.88189,-2.169922 1.96485,-2.169922 z m 6.99023,0 c 1.08296,0 1.96485,0.973618 1.96485,2.169922 0,1.196303 -0.88189,2.169922 -1.96485,2.169922 -1.08298,0 -1.96484,-0.973619 -1.96484,-2.169922 0,-1.196304 0.88189,-2.169922 1.96484,-2.169922 z' transform='matrix(32.178594,0,0,29.129737,-8737.3187,-1664.1247)' id='path3977' /%3E %3C/g%3E %3Cg id='g3983' style='fill:%23ffffff'/%3E %3Cg id='g3987' style='fill:%23ffffff'/%3E %3C/g%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 21.992188 A 6.9826789 6.9826789 0 0 0 310.04883 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 35.958984 A 6.9826789 6.9826789 0 0 0 324.01367 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 21.992188 z M 312.20703 27.580078 L 321.94336 27.642578 C 322.32865 27.645013 322.63647 27.956519 322.63281 28.341797 L 322.62109 29.603516 C 322.61743 29.988794 322.30326 30.297356 321.91797 30.294922 L 312.18164 30.232422 C 311.79635 30.229987 311.48853 29.918481 311.49219 29.533203 L 311.50391 28.271484 C 311.50757 27.886206 311.82174 27.577644 312.20703 27.580078 z ' id='path3997'/%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 59.992188 A 6.9826789 6.9826789 0 0 0 310.04883 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 73.958984 A 6.9826789 6.9826789 0 0 0 324.01367 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 59.992188 z M 316.49805 61.365234 L 317.76172 61.382812 C 318.14697 61.388692 318.45192 61.704576 318.44727 62.089844 L 318.4043 65.619141 L 321.94336 65.642578 C 322.32865 65.645013 322.63647 65.956519 322.63281 66.341797 L 322.62109 67.603516 C 322.61743 67.988794 322.30326 68.297356 321.91797 68.294922 L 318.37305 68.271484 L 318.33008 71.826172 C 318.32543 72.21144 318.0122 72.515645 317.62695 72.509766 L 316.36328 72.492188 C 315.97803 72.486309 315.67308 72.170424 315.67773 71.785156 L 315.7207 68.255859 L 312.18164 68.232422 C 311.79635 68.229987 311.48853 67.918481 311.49219 67.533203 L 311.50391 66.271484 C 311.50757 65.886206 311.82174 65.577644 312.20703 65.580078 L 315.75195 65.603516 L 315.79492 62.048828 C 315.79957 61.66356 316.1128 61.359355 316.49805 61.365234 z ' id='path3997-6'/%3E %3Cellipse style='fill:%23800000;fill-opacity:1;stroke-width:1.10310566' id='circle4073' cx='353.64172' cy='-28.97954' transform='scale(1,-1)' /%3E %3Cg id='g7787' transform='matrix(-0.02885349,0,0,-0.02885337,352.04486,75.172258)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cg id='g7731' transform='translate(-90.566882,42.049084)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cpath id='path7729' d='M 242.607,0 C 108.629,0 0.001,108.628 0.001,242.606 c 0,133.976 108.628,242.606 242.606,242.606 133.978,0 242.604,-108.631 242.604,-242.606 C 485.212,108.628 376.585,0 242.607,0 Z M 401.815,288.094 H 219.862 v 90.979 L 83.397,242.606 219.862,106.141 v 90.978 h 181.953 z' style='fill:%23ffffff;fill-opacity:1'/%3E %3C/g%3E %3Cg id='g7733' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7735' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7737' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7739' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7741' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7743' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7745' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7747' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7749' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7751' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7753' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7755' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7757' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7759' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7761' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3C/g%3E %3C/svg%3E") no-repeat;
+    position: absolute;
+    height: 18px;
+    width: 18px;
+    top: 6px;
+    content: "";
+    opacity: 0.8;
+    -webkit-transition: opacity 0.3s ease-in-out;
+    -moz-transition: opacity 0.3s ease-in-out;
+    -ms-transition: opacity 0.3s ease-in-out;
+    -o-transition: opacity 0.3s ease-in-out;
+    transition: opacity 0.3s ease-in-out;
+    background-position: -122px -57px;
+}
+
+.skip_button a span.skip_button_icon:before:hover {
+    opacity: 1;
+}
+
+.skip_button_disabled {
+    cursor: default !important;
+    padding: 13px 21px 13px 21px;
+}
+
+.close_button {
+    position: absolute;
+    background: #000000 url("data:image/svg+xml,%3Csvg fill='%23FFF' height='24' width='24' xmlns='http://www.w3.org/2000/svg'%3E %3Cpath d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/%3E %3Cpath d='M0 0h24v24H0z' fill='none'/%3E %3C/svg%3E") no-repeat scroll center center;
+    height: 16px;
+    width: 16px;
+    top: 0;
+    right: 0;
+    background-size: 18px 18px;
+    cursor: pointer;
+    padding: 1px;
+    z-index: 31;
+}
+
+.close_button:hover {
+    background-color: #000000;
+    border: 1px solid #ffffff;
+}
+
+.vast_clickthrough_layer {
+    /*IE Fix*/
+    background-color: white;
+    opacity: 0;
+}
+
+.fluid_ad_playing {
+    position: absolute;
+    background-color: black;
+    opacity: 0.8;
+    border-radius: 1px;
+    color: #ffffff;
+    font-size: 13px;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-weight: normal;
+    white-space: nowrap;
+    text-align: start;
+    line-height: 18px;
+    z-index: 10;
+    padding: 13px 21px 13px 21px;
+}
+
+.fluid_ad_cta {
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #ffffff;
+    font-size: 13px;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-weight: normal;
+    text-align: right;
+    cursor: pointer;
+    z-index: 10;
+    padding: 13px 21px 13px 13px;
+}
+
+.fluid_ad_cta a {
+    text-decoration: none;
+    color: #ffffff;
+    line-height: 18px;
+}
+
+.fluid_ad_cta:hover,
+.skip_button:not(.skip_button_disabled):hover {
+    background-color: rgba(0, 0, 0, 1);
+}
+
+.fluid_html_on_pause,
+.fluid_pseudo_poster {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    margin: auto;
+    z-index: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    pointer-events: none;
+}
+
+.fluid_html_on_pause * {
+    pointer-events: auto;
+}
+
+/*Mobile Layout*/
+.fluid_video_wrapper.mobile .skip_button {
+    bottom: 75px;
+}
+
+/*
+.fluid_video_wrapper.mobile .fluid_ad_cta {
+        bottom: 125px;
+}
+*/
+.fluid_initial_play {
+    width: 60px;
+    height: 60px;
+    border-radius: 50px;
+    cursor: pointer;
+}
+
+.fluid_initial_play_button {
+    margin-top: 15px;
+    margin-left: 23px;
+    border-style: solid;
+    border-width: 15px 0 15px 21px;
+    border-color: transparent transparent transparent #ffffff;
+}
+
+.fluid_initial_pause_button {
+    margin-top: 15px;
+    margin-left: 17px;
+    width: 8px;
+    height: 31px;
+    border: 9px solid white;
+    border-top: 0;
+    border-bottom: 0;
+}
+
+.fluid_timeline_preview {
+    bottom: 11px;
+    color: #ffffff;
+    font-size: 13px;
+    line-height: 18px;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-weight: normal;
+    text-align: start;
+    padding: 13px 21px 13px 21px;
+    background-color: rgba(0, 0, 0, 0.85);
+    border-radius: 1px;
+}
+
+/* Duration */
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_fluid_control_duration {
+    display: inline-block;
+    position: absolute;
+    left: 32px;
+    height: 24px;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-size: 13px;
+    font-weight: normal;
+    font-style: normal;
+    text-align: left;
+    text-decoration: none;
+    line-height: 21px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_fluid_control_duration.cardboard_time {
+    left: 13px;
+    top: -15px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_fluid_control_duration.cardboard_time .ad_timer_prefix {
+    color: #F2C94C;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .ad_countdown .ad_timer_prefix {
+    color: #F2C94C;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .ad_countdown {
+    /*display: none;*/
+    position: absolute;
+    right: 0;
+    width: 75px;
+    bottom: 5px;
+    height: 24px;
+    color: red;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-size: 13px;
+    font-weight: normal;
+    font-style: normal;
+    text-align: left;
+    text-decoration: none;
+    line-height: 21px;
+}
+
+.initial_controls_show {
+    visibility: visible !important;
+    opacity: 1 !important;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container {
+    color: white;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: -moz-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%); /* FF3.6-15 */
+    background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%); /* Chrome10-25,Safari5.1-6 */
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#ad000000', GradientType=0); /* IE6-9 */
+    height: 100%;
+    width: 100%;
+    z-index: 0;
+    pointer-events: none;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel {
+    height: 96px;
+    width: 72px;
+    left: 10px;
+    top: 10px;
+    position: absolute;
+    background: rgba(0, 0, 0, 0.7);
+    text-align: center;
+    border-radius: 6px;
+    overflow: hidden;
+    pointer-events: auto;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel .fluid_vr_button {
+    cursor: pointer;
+    display: inline-block;
+    text-align: left;
+    height: 24px;
+    width: 24px;
+    position: relative;
+    background: url("data:image/svg+xml,%3Csvg xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg' width='388.75' height='96' version='1.1' viewBox='0 0 388.75 96' id='svg63'%3E %3Cpath id='path4087' d='m 347.64062,35.959 a 6.9826789,6.9826789 0 0 0 6.98438,-6.984375 6.9826789,6.9826789 0 0 0 -6.98438,-6.982422 6.9826789,6.9826789 0 0 0 -6.98242,6.982422 6.9826789,6.9826789 0 0 0 6.98242,6.984375 z m 0,-2.476562 a 4.5078053,4.5078053 0 0 1 -4.50781,-4.507813 4.5078053,4.5078053 0 0 1 4.50781,-4.507812 4.5078053,4.5078053 0 0 1 4.50781,4.507812 4.5078053,4.5078053 0 0 1 -4.50781,4.507813 z' style='fill:%23ffffff;fill-opacity:1;stroke-width:1.70873225' /%3E %3Cpath style='fill:%23ffffff;fill-opacity:1;stroke-width:1.00886583' d='M 273.55469,22 C 272.69375,22 272,22.693749 272,23.554688 V 34.445312 C 272,35.306251 272.69375,36 273.55469,36 h 10.89062 C 285.30625,36 286,35.306251 286,34.445312 V 23.554688 C 286,22.693749 285.30625,22 284.44531,22 Z m 3.61133,4.541016 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z m 4.75,0 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z' id='rect7816' /%3E %3Cg transform='translate(-3702,106)' id='g44'%3E %3CclipPath id='q' style='clip-rule:evenodd'%3E %3Cpath d='m 3702,-106 h 272 v 96 h -272 z' id='path6' style='fill:%23ffffff'/%3E %3C/clipPath%3E %3Cg clip-path='url(%23q)' id='g42'%3E %3Cuse transform='translate(3757,-86)' xlink:href='%23o' id='use9' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3757,-48)' xlink:href='%23i' id='use11' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3830,-84)' xlink:href='%23h' id='use13' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-86)' xlink:href='%23g' id='use15' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-48)' xlink:href='%23f' id='use17' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-46)' xlink:href='%23e' id='use19' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3831,-46)' xlink:href='%23d' id='use21' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3865,-44)' xlink:href='%23c' id='use23' style='fill:%23f2c94c' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-84)' xlink:href='%23b' id='use25' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3866,-83)' xlink:href='%23a' id='use27' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-47)' xlink:href='%23n' id='use29' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cmask id='p'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23m' id='use31' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/mask%3E %3Cg mask='url(%23p)' id='g36'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23l' id='use34' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3Cuse transform='translate(3904,-85)' xlink:href='%23k' id='use38' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-85)' xlink:href='%23j' id='use40' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3C/g%3E %3Cdefs id='defs61'%3E %3Cpath id='o' d='m 0,5.5924 v 5.8152 H 3.7778 L 8.5,16.2537 V 0.7467 L 3.7778,5.5928 H 0 Z M 12.75,8.5 c 0,-1.7155 -0.9633,-3.1887 -2.3611,-3.9059 v 7.8021 C 11.7867,11.6887 12.75,10.2155 12.75,8.5 Z M 10.3889,0 v 1.9966 c 2.7294,0.83352 4.7222,3.431 4.7222,6.5034 0,3.0724 -1.9928,5.6699 -4.7222,6.5034 V 17 C 14.1761,16.118 17,12.6482 17,8.5 17,4.3518 14.1761,0.882 10.3889,0 Z' /%3E %3Cpath id='i' d='m 12.75,8.5 c 0,-1.6717 -0.9633,-3.1072 -2.3611,-3.8061 V 6.7811 L 12.7028,9.095 C 12.7311,8.90611 12.75,8.70778 12.75,8.5 Z m 2.3611,0 c 0,0.88778 -0.1889,1.7189 -0.51,2.4933 l 1.4261,1.4261 C 16.6506,11.2483 17,9.9167 17,8.5 17,4.4578 14.1761,1.0767 10.3889,0.2172 V 2.1628 C 13.1183,2.97502 15.1111,5.5061 15.1111,8.5 Z M 1.1991,0 -3e-4,1.1994 4.4669,5.6666 H -3e-4 v 5.6666 h 3.7778 l 4.7222,4.7223 V 9.6993 l 4.0139,4.0139 c -0.6328,0.4911 -1.3411,0.8784 -2.125,1.1145 v 1.9455 c 1.3033,-0.2927 2.4839,-0.8972 3.485,-1.7094 l 1.9267,1.9361 1.1994,-1.1994 -8.5,-8.5 L 1.1991,-1e-4 Z m 7.3006,0.94444 -1.9739,1.9739 1.9739,1.9739 z' /%3E %3Cpath id='h' d='M 12.444,0 H 1.555 C 0.69166,0 -6e-4,0.7 -6e-4,1.5556 v 10.889 c 0,0.8556 0.69222,1.5556 1.5556,1.5556 h 10.889 c 0.8556,0 1.5556,-0.7 1.5556,-1.5556 V 1.5556 C 13.9996,0.70004 13.2996,0 12.444,0 Z M 6.2218,9.3333 H 5.0551 V 7.7777 H 3.4995 V 9.3333 H 2.3328 V 4.6666 H 3.4995 V 6.611 H 5.0551 V 4.6666 H 6.2218 Z M 7.7774,4.6666 h 3.1111 c 0.4278,0 0.7778,0.35 0.7778,0.77777 v 3.1111 c 0,0.42777 -0.35,0.77777 -0.7778,0.77777 H 7.7774 v -4.6667 z m 1.1667,3.5 h 1.5556 V 5.8333 H 8.9441 Z' /%3E %3Cpath id='g' d='M 0,0 V 17 L 13,8.5 Z' /%3E %3Cpath id='f' d='M 0,17 H 4.3333 V 0 H 0 Z M 8.6667,0 V 17 H 13 V 0 Z' /%3E %3Cpath id='e' d='m 0,11 h 3 v 3 H 5 V 9 H 0 Z M 3,3 H 0 V 5 H 5 V 0 H 3 Z m 6,11 h 2 v -3 h 3 V 9 H 9 Z M 11,3 V 0 H 9 v 5 h 5 V 3 Z' /%3E %3Cpath id='d' d='M 0,12 8.5,6 0,0 Z M 10,0 v 12 h 2 V 0 Z' /%3E %3Cpath id='c' d='M 1.52,4.5 C 1.52,2.961 2.632,1.71 4,1.71 H 7.2 V 0 H 4 C 1.792,0 0,2.016 0,4.5 0,6.984 1.792,9 4,9 H 7.2 V 7.29 H 4 C 2.632,7.29 1.52,6.039 1.52,4.5 Z M 4.8,5.4 h 6.4 V 3.6 H 4.8 Z M 12,0 H 8.8 V 1.71 H 12 c 1.368,0 2.48,1.251 2.48,2.79 0,1.539 -1.112,2.79 -2.48,2.79 H 8.8 V 9 H 12 C 14.208,9 16,6.984 16,4.5 16,2.016 14.208,0 12,0 Z' /%3E %3Cpath id='b' d='M 2,9 H 0 v 5 H 5 V 12 H 2 Z M 0,5 H 2 V 2 H 5 V 0 H 0 Z m 12,7 H 9 v 2 h 5 V 9 H 12 Z M 9,0 v 2 h 3 v 3 h 2 V 0 Z' /%3E %3Cpath id='a' d='M 4.4546,8.7015 1.1137,5.2537 1e-4,6.403 4.4546,11 14,1.1492 12.8864,-1e-4 4.4546,8.7014 Z' /%3E %3Cpath id='n' d='M 12.348,7.686 C 12.3768,7.462 12.3984,7.238 12.3984,7 12.3984,6.762 12.3768,6.538 12.348,6.314 L 13.8664,5.159 C 14.0032,5.054 14.0391,4.865 13.9528,4.711 L 12.5135,2.289 C 12.4272,2.135 12.2329,2.079 12.0745,2.135 l -1.7919,0.7 C 9.90842,2.555 9.50543,2.324 9.0664,2.149 L 8.79294,0.294 C 8.77135,0.126 8.62022,0 8.44031,0 H 5.56171 C 5.38181,0 5.23068,0.126 5.20909,0.294 L 4.93563,2.149 C 4.49665,2.324 4.09365,2.562 3.71943,2.835 l -1.7919,-0.7 C 1.76201,2.072 1.5749,2.135 1.48855,2.289 l -1.4393,2.422 c -0.093553,0.154 -0.050374,0.343 0.086356,0.448 l 1.5184,1.155 C 1.625226,6.538 1.603636,6.769 1.603636,7 c 0,0.231 0.02159,0.462 0.05037,0.686 l -1.5184,1.155 c -0.13673,0.105 -0.17271,0.294 -0.086356,0.448 l 1.4393,2.422 c 0.08635,0.154 0.28066,0.21 0.43898,0.154 l 1.7919,-0.7 c 0.37421,0.28 0.77721,0.511 1.2162,0.686 l 0.27346,1.855 C 5.23068,13.874 5.38181,14 5.56171,14 h 2.8786 c 0.17991,0 0.33104,-0.126 0.35263,-0.294 L 9.0664,11.851 c 0.43898,-0.175 0.84197,-0.413 1.2162,-0.686 l 1.7919,0.7 c 0.1655,0.063 0.3527,0 0.439,-0.154 L 13.9528,9.289 C 14.0391,9.135 14.0032,8.946 13.8664,8.841 Z M 7.0011,9.45 C 5.6122,9.45 4.4824,8.351 4.4824,7 4.4824,5.649 5.6122,4.55 7.0011,4.55 8.39,4.55 9.5198,5.649 9.5198,7 9.5198,8.351 8.39,9.45 7.0011,9.45 Z' /%3E %3Cpath id='m' d='M 0,0 H 16 V 12 H 0 Z' /%3E %3Cpath id='l' d='m 0,0 v -2 h -2 v 2 z m 16,0 h 2 v -2 h -2 z m 0,12 v 2 h 2 V 12 Z M 0,12 h -2 v 2 H 0 Z M 0,2 H 16 V -2 H 0 Z M 14,0 v 12 h 4 V 0 Z m 2,10 H 0 v 4 H 16 Z M 2,12 V 0 h -4 v 12 z' /%3E %3Cpath id='k' d='M 12,5.2941 H 8.5714 V 0 H 3.4285 V 5.2941 H -1e-4 l 6,6.1765 6,-6.1765 z M 0,13.2353 V 15 h 12 v -1.7647 z' /%3E %3Cpath id='j' d='M 9.3333,0 H 4.6666 V 1.5238 H 9.3333 Z M 6.2222,9.9048 H 7.7778 V 5.3334 H 6.2222 Z M 12.4678,4.8686 13.5722,3.7867 C 13.2378,3.39813 12.8722,3.03241 12.4756,2.7124 L 11.3711,3.7943 C 10.1656,2.84953 8.6489,2.2857 7,2.2857 3.1344,2.2857 0,5.3562 0,9.1429 0,12.9295 3.1267,16 7,16 10.8733,16 14,12.9295 14,9.1429 14,7.5277 13.4244,6.0419 12.4678,4.8686 Z M 7,14.4762 C 3.99,14.4762 1.5556,12.0914 1.5556,9.1429 1.5556,6.1943 3.99,3.8096 7,3.8096 c 3.01,0 5.4444,2.3848 5.4444,5.3333 0,2.9485 -2.4344,5.3333 -5.4444,5.3333 z' /%3E %3C/defs%3E %3Cg id='g3989' transform='matrix(0.03107656,0,0,0.03432918,271.52581,57.128037)' style='fill:%23ffffff'%3E %3Cg id='g3979' style='fill:%23ffffff'%3E %3Cpath style='fill:%23ffffff;stroke-width:0.03266241' d='m 273.49023,60.4375 c -1.07158,0 -1.96484,0.958273 -1.96484,2.169922 v 6.61914 c 0,1.216352 0.89727,2.167935 1.96484,2.167969 h 2.87305 c 0.52417,0 1.01765,-0.2246 1.39063,-0.634765 l 1,-1.103516 c 0.19059,-0.211639 0.45448,-0.333984 0.72656,-0.333984 0.27207,0 0.53829,0.122547 0.73047,0.335937 l 0.99804,1.101563 c 0.37212,0.409203 0.86646,0.634765 1.39063,0.634765 h 2.87305 c 1.07158,0 1.96484,-0.95632 1.96484,-2.167969 v -6.61914 c 0,-1.216352 -0.89727,-2.169922 -1.96484,-2.169922 z m 2.4961,3.308594 c 1.08295,0 1.96484,0.973618 1.96484,2.169922 0,1.196303 -0.88185,2.169921 -1.96484,2.169922 -1.08299,0 -1.96485,-0.973619 -1.96485,-2.169922 0,-1.196304 0.88189,-2.169922 1.96485,-2.169922 z m 6.99023,0 c 1.08296,0 1.96485,0.973618 1.96485,2.169922 0,1.196303 -0.88189,2.169922 -1.96485,2.169922 -1.08298,0 -1.96484,-0.973619 -1.96484,-2.169922 0,-1.196304 0.88189,-2.169922 1.96484,-2.169922 z' transform='matrix(32.178594,0,0,29.129737,-8737.3187,-1664.1247)' id='path3977' /%3E %3C/g%3E %3Cg id='g3983' style='fill:%23ffffff'/%3E %3Cg id='g3987' style='fill:%23ffffff'/%3E %3C/g%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 21.992188 A 6.9826789 6.9826789 0 0 0 310.04883 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 35.958984 A 6.9826789 6.9826789 0 0 0 324.01367 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 21.992188 z M 312.20703 27.580078 L 321.94336 27.642578 C 322.32865 27.645013 322.63647 27.956519 322.63281 28.341797 L 322.62109 29.603516 C 322.61743 29.988794 322.30326 30.297356 321.91797 30.294922 L 312.18164 30.232422 C 311.79635 30.229987 311.48853 29.918481 311.49219 29.533203 L 311.50391 28.271484 C 311.50757 27.886206 311.82174 27.577644 312.20703 27.580078 z ' id='path3997'/%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 59.992188 A 6.9826789 6.9826789 0 0 0 310.04883 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 73.958984 A 6.9826789 6.9826789 0 0 0 324.01367 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 59.992188 z M 316.49805 61.365234 L 317.76172 61.382812 C 318.14697 61.388692 318.45192 61.704576 318.44727 62.089844 L 318.4043 65.619141 L 321.94336 65.642578 C 322.32865 65.645013 322.63647 65.956519 322.63281 66.341797 L 322.62109 67.603516 C 322.61743 67.988794 322.30326 68.297356 321.91797 68.294922 L 318.37305 68.271484 L 318.33008 71.826172 C 318.32543 72.21144 318.0122 72.515645 317.62695 72.509766 L 316.36328 72.492188 C 315.97803 72.486309 315.67308 72.170424 315.67773 71.785156 L 315.7207 68.255859 L 312.18164 68.232422 C 311.79635 68.229987 311.48853 67.918481 311.49219 67.533203 L 311.50391 66.271484 C 311.50757 65.886206 311.82174 65.577644 312.20703 65.580078 L 315.75195 65.603516 L 315.79492 62.048828 C 315.79957 61.66356 316.1128 61.359355 316.49805 61.365234 z ' id='path3997-6'/%3E %3Cellipse style='fill:%23800000;fill-opacity:1;stroke-width:1.10310566' id='circle4073' cx='353.64172' cy='-28.97954' transform='scale(1,-1)' /%3E %3Cg id='g7787' transform='matrix(-0.02885349,0,0,-0.02885337,352.04486,75.172258)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cg id='g7731' transform='translate(-90.566882,42.049084)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cpath id='path7729' d='M 242.607,0 C 108.629,0 0.001,108.628 0.001,242.606 c 0,133.976 108.628,242.606 242.606,242.606 133.978,0 242.604,-108.631 242.604,-242.606 C 485.212,108.628 376.585,0 242.607,0 Z M 401.815,288.094 H 219.862 v 90.979 L 83.397,242.606 219.862,106.141 v 90.978 h 181.953 z' style='fill:%23ffffff;fill-opacity:1'/%3E %3C/g%3E %3Cg id='g7733' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7735' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7737' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7739' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7741' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7743' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7745' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7747' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7749' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7751' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7753' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7755' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7757' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7759' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7761' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3C/g%3E %3C/svg%3E") no-repeat;
+    opacity: 0.8;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel .fluid_vr_button:hover {
+    opacity: 1;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel .fluid_vr_joystick_up {
+    background-position: -336px -55px;
+    -webkit-transform: rotate(270deg); /* Chrome, Opera 15+, Safari 3.1+ */
+    -ms-transform: rotate(270deg); /* IE 9 */
+    transform: rotate(270deg); /* Firefox 16+, IE 10+, Opera  */
+    display: block;
+    left: calc(50% - 12px);
+    top: 0;
+    position: absolute;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel .fluid_vr_joystick_left {
+    background-position: -336px -55px;
+    -webkit-transform: rotate(180deg); /* Chrome, Opera 15+, Safari 3.1+ */
+    -ms-transform: rotate(1890deg); /* IE 9 */
+    transform: rotate(180deg); /* Firefox 16+, IE 10+, Opera  */
+    display: block;
+    left: 0;
+    top: 24px;
+    position: absolute;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel .fluid_vr_joystick_right {
+    background-position: -336px -55px;
+    -webkit-transform: rotate(0deg); /* Chrome, Opera 15+, Safari 3.1+ */
+    -ms-transform: rotate(0deg); /* IE 9 */
+    transform: rotate(0deg); /* Firefox 16+, IE 10+, Opera  */
+    display: block;
+    right: 0;
+    top: 24px;
+    position: absolute;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel .fluid_vr_joystick_down {
+    background-position: -336px -55px;
+    -webkit-transform: rotate(90deg); /* Chrome, Opera 15+, Safari 3.1+ */
+    -ms-transform: rotate(90deg); /* IE 9 */
+    transform: rotate(90deg); /* Firefox 16+, IE 10+, Opera  */
+    display: block;
+    left: calc(50% - 12px);
+    top: 48px;
+    position: absolute;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel .fluid_vr_joystick_zoomdefault {
+    background-position: -336px -17px;
+    top: 72px;
+    -webkit-transform: rotate(0deg); /* Chrome, Opera 15+, Safari 3.1+ */
+    -ms-transform: rotate(0deg); /* IE 9 */
+    transform: rotate(0deg); /* Firefox 16+, IE 10+, Opera  */
+    position: absolute;
+    left: calc(50% - 12px);
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel .fluid_vr_joystick_zoomin {
+    background-position: -305px -55px;
+    top: 72px;
+    -webkit-transform: rotate(0deg); /* Chrome, Opera 15+, Safari 3.1+ */
+    -ms-transform: rotate(0deg); /* IE 9 */
+    transform: rotate(0deg); /* Firefox 16+, IE 10+, Opera  */
+    position: absolute;
+    right: 0;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vr_container .fluid_vr_joystick_panel .fluid_vr_joystick_zoomout {
+    background-position: -305px -17px;
+    top: 72px;
+    -webkit-transform: rotate(0deg); /* Chrome, Opera 15+, Safari 3.1+ */
+    -ms-transform: rotate(0deg); /* IE 9 */
+    transform: rotate(0deg); /* Firefox 16+, IE 10+, Opera  */
+    position: absolute;
+    left: 0;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container.fluid_vr_controls_container {
+    width: 50% !important;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container.fluid_vr2_controls_container {
+    width: 50% !important;
+    left: 50%;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container {
+    color: white;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: -moz-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%); /* FF3.6-15 */
+    background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%); /* Chrome10-25,Safari5.1-6 */
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#ad000000', GradientType=0); /* IE6-9 */
+    height: 53px;
+    z-index: 1;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vpaid_iframe {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    z-index: -10;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vpaid_nonlinear_slot_iframe {
+    z-index: 30;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_vpaid_slot {
+    position: absolute !important;
+    top: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    left: 0 !important;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_subtitles_container {
+    color: white;
+    position: absolute;
+    bottom: 46px;
+    left: 0;
+    right: 0;
+    height: auto;
+    z-index: 1;
+    text-align: center;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_subtitles_container div {
+    display: inline;
+    background: black;
+    color: white;
+    font-size: 1em;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    padding: 0.25em;
+    border-radius: 4px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fade_out {
+    visibility: hidden;
+    opacity: 0;
+    -webkit-transition: visibility 0.5s, opacity 0.5s; /* Safari */
+    transition: visibility 0.5s, opacity 0.5s;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fade_in {
+    visibility: visible;
+    opacity: 1;
+    -webkit-transition: visibility 0.5s, opacity 0.5s; /* Safari */
+    transition: visibility 0.5s, opacity 0.5s;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default.pseudo_fullscreen {
+    width: 100% !important;
+    height: 100% !important;
+    top: 0;
+    left: 0;
+    position: fixed;
+    z-index: 99999;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default:-webkit-full-screen {
+    width: 100% !important;
+    height: 100% !important;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default:-ms-fullscreen {
+    width: 100% !important;
+    height: 100% !important;
+    position: absolute;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_context_menu {
+    background-color: #000000;
+    color: #ffffff;
+    font-size: 13px;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-weight: normal;
+    white-space: nowrap;
+    text-align: start;
+    z-index: 11;
+    opacity: 0.8;
+    border-radius: 1px;
+}
+
+/* IE 10+ */
+_:-ms-lang(x),
+.fluid_video_wrapper.fluid_player_layout_default .fluid_context_menu {
+    text-align: left;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_context_menu ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_context_menu ul li {
+    padding: 13px 71px 13px 21px;
+    cursor: pointer;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_context_menu ul li + li {
+    border-top: 1px solid #000000;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_context_menu ul li:hover {
+    background-color: #1e1e1e;
+    color: #fbfaff;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_left {
+    width: 24px;
+    left: 20px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container.skip_controls .fluid_controls_left {
+    width: 80px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button {
+    width: 24px;
+    height: 24px;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right {
+    left: 60px;
+    right: 20px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container.skip_controls .fluid_controls_right {
+    left: 110px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_left,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right {
+    position: absolute;
+    height: 24px;
+    top: 23px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container {
+    height: 14px;
+    position: absolute;
+    left: 13px;
+    right: 13px;
+    z-index: 1;
+    top: 8px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container .fluid_controls_progress {
+    position: absolute;
+    top: 5px;
+    width: 100%;
+    height: 4px;
+    background-color: rgba(255, 255, 255, 0.25);
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container .fluid_controls_buffered {
+    position: absolute;
+    top: 5px;
+    width: 0;
+    height: 3px;
+    background-color: rgba(255, 255, 255, 0.5);
+    z-index: -1;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container .fluid_controls_progress,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container .fluid_controls_progress .fluid_controls_currentprogress {
+    position: absolute;
+    height: 3px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container:hover .fluid_controls_progress,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container:hover .fluid_controls_buffered,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container:hover .fluid_controls_ad_markers_holder {
+    margin-top: -1px;
+    height: 5px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container:hover .fluid_controls_progress .fluid_controls_currentprogress {
+    height: 5px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container .fluid_timeline_preview_container {
+    border: 1px solid #262626;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container .fluid_timeline_preview_container, .fluid_timeline_preview_container_shadow {
+    bottom: 14px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container.fluid_slider .fluid_controls_progress .fluid_controls_currentprogress .fluid_controls_currentpos {
+    background-color: white;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container.fluid_slider .fluid_controls_progress .fluid_controls_currentprogress .fluid_controls_currentpos,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container.fluid_ad_slider .fluid_controls_progress .fluid_controls_currentprogress .fluid_controls_currentpos {
+    opacity: 0;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container.fluid_slider:hover .fluid_controls_progress .fluid_controls_currentprogress .fluid_controls_currentpos {
+    opacity: 1;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container.fluid_slider .fluid_controls_progress .fluid_controls_currentprogress .fluid_controls_currentpos {
+    -webkit-transition: opacity 0.3s; /* Safari */
+    transition: opacity 0.3s;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_ad_markers_holder {
+    position: absolute;
+    top: 5px;
+    width: 100%;
+    height: 3px;
+    z-index: 2;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_ad_marker {
+    position: absolute;
+    background-color: #FFCC00;
+    height: 100%;
+    width: 6px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_control_volume_container {
+    height: 24px;
+    width: 56px;
+    left: 25px;
+    top: -1px;
+    z-index: 2;
+    opacity: 0.8;
+    -webkit-transition: opacity 0.3s ease-in-out;
+    -moz-transition: opacity 0.3s ease-in-out;
+    -ms-transition: opacity 0.3s ease-in-out;
+    -o-transition: opacity 0.3s ease-in-out;
+    transition: opacity 0.3s ease-in-out;
+    display: none;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_control_volume_container:hover {
+    opacity: 1;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_control_volume_container .fluid_control_volume {
+    position: relative;
+    height: 3px;
+    width: 100%;
+    margin-top: 10px;
+    background-color: rgba(171, 172, 172, 0.68);
+    z-index: 3;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_control_volume_container .fluid_control_volume .fluid_control_currentvolume {
+    float: left;
+    background-color: white;
+    height: 3px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_control_volume_container .fluid_control_volume .fluid_control_currentvolume .fluid_control_volume_currentpos {
+    background-color: white;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container .fluid_controls_progress .fluid_controls_currentpos {
+    right: -4px;
+    z-index: 3;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_control_volume_container .fluid_control_volume .fluid_control_currentvolume .fluid_control_volume_currentpos,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container .fluid_controls_progress .fluid_controls_currentpos {
+    width: 11px;
+    height: 11px;
+    position: absolute;
+    top: -4px;
+    border-radius: 6px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_progress_container .fluid_controls_progress .fluid_controls_currentpos {
+    width: 13px;
+    height: 13px;
+    position: absolute;
+    top: -4px;
+    border-radius: 6px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container.no_volume_bar .fluid_controls_right .fluid_control_volume_container {
+    display: none;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_slider {
+    cursor: pointer;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container div div {
+    display: block;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button.fluid_button_fullscreen,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button.fluid_button_fullscreen_exit {
+    float: right;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_video_source,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_subtitles,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_cardboard {
+    font-size: 13px;
+    height: 24px;
+    line-height: 24px;
+    float: right;
+    cursor: pointer;
+    position: relative;
+    text-align: right;
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+    -khtml-user-select: none; /* Konqueror HTML */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+    user-select: none;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_video_source .fluid_video_sources_title,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_subtitles .fluid_subtitles_title {
+    width: 80px;
+    overflow: hidden;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_subtitles .fluid_subtitles_list,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_video_source .fluid_video_sources_list,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_video_playback_rates {
+    position: absolute;
+    bottom: 25px;
+    right: 3px;
+    z-index: 888888;
+    opacity: 99%;
+    background-color: rgba(0, 0, 0, 1);
+    border-radius: 2px;
+    color: #ffffff;
+    font-size: 13px;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-weight: normal;
+    white-space: nowrap;
+    text-align: start;
+    width: max-content;
+    padding: 0.5em;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_subtitles .fluid_subtitles_list .fluid_subtitle_list_item,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_video_source .fluid_video_sources_list .fluid_video_source_list_item {
+    padding: 12px 34px 12px 24px;
+    line-height: 15px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_video_source .fluid_video_sources_list .fluid_video_source_list_item:hover,
+.fluid_video_playback_rates_item:hover,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_subtitles .fluid_subtitles_list .fluid_subtitle_list_item:hover {
+    background-color: #3a3a3a;
+}
+
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_control_volume_container,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button.fluid_button_volume,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button.fluid_button_mute {
+    position: absolute;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button.fluid_button_volume,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button.fluid_button_mute {
+    left: -10px;
+}
+
+/* Button Icons */
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_play,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_pause,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_skip_back,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_skip_forward,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_volume,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_mute,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_video_source,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_fullscreen,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_fullscreen_exit,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_playback_rate,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_download,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_theatre,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_subtitles,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_cardboard {
+    display: inline-block;
+    text-align: left;
+    height: 24px;
+    width: 24px;
+    position: relative;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_play:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_pause:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_skip_back:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_skip_forward:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_volume:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_mute:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_video_source:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_fullscreen:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_fullscreen_exit:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_playback_rate:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_download:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_theatre:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_subtitles:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_cardboard:before {
+    background: url("data:image/svg+xml,%3Csvg xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg' width='388.75' height='96' version='1.1' viewBox='0 0 388.75 96' id='svg63'%3E %3Cpath id='path4087' d='m 347.64062,35.959 a 6.9826789,6.9826789 0 0 0 6.98438,-6.984375 6.9826789,6.9826789 0 0 0 -6.98438,-6.982422 6.9826789,6.9826789 0 0 0 -6.98242,6.982422 6.9826789,6.9826789 0 0 0 6.98242,6.984375 z m 0,-2.476562 a 4.5078053,4.5078053 0 0 1 -4.50781,-4.507813 4.5078053,4.5078053 0 0 1 4.50781,-4.507812 4.5078053,4.5078053 0 0 1 4.50781,4.507812 4.5078053,4.5078053 0 0 1 -4.50781,4.507813 z' style='fill:%23ffffff;fill-opacity:1;stroke-width:1.70873225' /%3E %3Cpath style='fill:%23ffffff;fill-opacity:1;stroke-width:1.00886583' d='M 273.55469,22 C 272.69375,22 272,22.693749 272,23.554688 V 34.445312 C 272,35.306251 272.69375,36 273.55469,36 h 10.89062 C 285.30625,36 286,35.306251 286,34.445312 V 23.554688 C 286,22.693749 285.30625,22 284.44531,22 Z m 3.61133,4.541016 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z m 4.75,0 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z' id='rect7816' /%3E %3Cg transform='translate(-3702,106)' id='g44'%3E %3CclipPath id='q' style='clip-rule:evenodd'%3E %3Cpath d='m 3702,-106 h 272 v 96 h -272 z' id='path6' style='fill:%23ffffff'/%3E %3C/clipPath%3E %3Cg clip-path='url(%23q)' id='g42'%3E %3Cuse transform='translate(3757,-86)' xlink:href='%23o' id='use9' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3757,-48)' xlink:href='%23i' id='use11' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3830,-84)' xlink:href='%23h' id='use13' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-86)' xlink:href='%23g' id='use15' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-48)' xlink:href='%23f' id='use17' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-46)' xlink:href='%23e' id='use19' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3831,-46)' xlink:href='%23d' id='use21' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3865,-44)' xlink:href='%23c' id='use23' style='fill:%23f2c94c' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-84)' xlink:href='%23b' id='use25' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3866,-83)' xlink:href='%23a' id='use27' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-47)' xlink:href='%23n' id='use29' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cmask id='p'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23m' id='use31' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/mask%3E %3Cg mask='url(%23p)' id='g36'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23l' id='use34' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3Cuse transform='translate(3904,-85)' xlink:href='%23k' id='use38' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-85)' xlink:href='%23j' id='use40' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3C/g%3E %3Cdefs id='defs61'%3E %3Cpath id='o' d='m 0,5.5924 v 5.8152 H 3.7778 L 8.5,16.2537 V 0.7467 L 3.7778,5.5928 H 0 Z M 12.75,8.5 c 0,-1.7155 -0.9633,-3.1887 -2.3611,-3.9059 v 7.8021 C 11.7867,11.6887 12.75,10.2155 12.75,8.5 Z M 10.3889,0 v 1.9966 c 2.7294,0.83352 4.7222,3.431 4.7222,6.5034 0,3.0724 -1.9928,5.6699 -4.7222,6.5034 V 17 C 14.1761,16.118 17,12.6482 17,8.5 17,4.3518 14.1761,0.882 10.3889,0 Z' /%3E %3Cpath id='i' d='m 12.75,8.5 c 0,-1.6717 -0.9633,-3.1072 -2.3611,-3.8061 V 6.7811 L 12.7028,9.095 C 12.7311,8.90611 12.75,8.70778 12.75,8.5 Z m 2.3611,0 c 0,0.88778 -0.1889,1.7189 -0.51,2.4933 l 1.4261,1.4261 C 16.6506,11.2483 17,9.9167 17,8.5 17,4.4578 14.1761,1.0767 10.3889,0.2172 V 2.1628 C 13.1183,2.97502 15.1111,5.5061 15.1111,8.5 Z M 1.1991,0 -3e-4,1.1994 4.4669,5.6666 H -3e-4 v 5.6666 h 3.7778 l 4.7222,4.7223 V 9.6993 l 4.0139,4.0139 c -0.6328,0.4911 -1.3411,0.8784 -2.125,1.1145 v 1.9455 c 1.3033,-0.2927 2.4839,-0.8972 3.485,-1.7094 l 1.9267,1.9361 1.1994,-1.1994 -8.5,-8.5 L 1.1991,-1e-4 Z m 7.3006,0.94444 -1.9739,1.9739 1.9739,1.9739 z' /%3E %3Cpath id='h' d='M 12.444,0 H 1.555 C 0.69166,0 -6e-4,0.7 -6e-4,1.5556 v 10.889 c 0,0.8556 0.69222,1.5556 1.5556,1.5556 h 10.889 c 0.8556,0 1.5556,-0.7 1.5556,-1.5556 V 1.5556 C 13.9996,0.70004 13.2996,0 12.444,0 Z M 6.2218,9.3333 H 5.0551 V 7.7777 H 3.4995 V 9.3333 H 2.3328 V 4.6666 H 3.4995 V 6.611 H 5.0551 V 4.6666 H 6.2218 Z M 7.7774,4.6666 h 3.1111 c 0.4278,0 0.7778,0.35 0.7778,0.77777 v 3.1111 c 0,0.42777 -0.35,0.77777 -0.7778,0.77777 H 7.7774 v -4.6667 z m 1.1667,3.5 h 1.5556 V 5.8333 H 8.9441 Z' /%3E %3Cpath id='g' d='M 0,0 V 17 L 13,8.5 Z' /%3E %3Cpath id='f' d='M 0,17 H 4.3333 V 0 H 0 Z M 8.6667,0 V 17 H 13 V 0 Z' /%3E %3Cpath id='e' d='m 0,11 h 3 v 3 H 5 V 9 H 0 Z M 3,3 H 0 V 5 H 5 V 0 H 3 Z m 6,11 h 2 v -3 h 3 V 9 H 9 Z M 11,3 V 0 H 9 v 5 h 5 V 3 Z' /%3E %3Cpath id='d' d='M 0,12 8.5,6 0,0 Z M 10,0 v 12 h 2 V 0 Z' /%3E %3Cpath id='c' d='M 1.52,4.5 C 1.52,2.961 2.632,1.71 4,1.71 H 7.2 V 0 H 4 C 1.792,0 0,2.016 0,4.5 0,6.984 1.792,9 4,9 H 7.2 V 7.29 H 4 C 2.632,7.29 1.52,6.039 1.52,4.5 Z M 4.8,5.4 h 6.4 V 3.6 H 4.8 Z M 12,0 H 8.8 V 1.71 H 12 c 1.368,0 2.48,1.251 2.48,2.79 0,1.539 -1.112,2.79 -2.48,2.79 H 8.8 V 9 H 12 C 14.208,9 16,6.984 16,4.5 16,2.016 14.208,0 12,0 Z' /%3E %3Cpath id='b' d='M 2,9 H 0 v 5 H 5 V 12 H 2 Z M 0,5 H 2 V 2 H 5 V 0 H 0 Z m 12,7 H 9 v 2 h 5 V 9 H 12 Z M 9,0 v 2 h 3 v 3 h 2 V 0 Z' /%3E %3Cpath id='a' d='M 4.4546,8.7015 1.1137,5.2537 1e-4,6.403 4.4546,11 14,1.1492 12.8864,-1e-4 4.4546,8.7014 Z' /%3E %3Cpath id='n' d='M 12.348,7.686 C 12.3768,7.462 12.3984,7.238 12.3984,7 12.3984,6.762 12.3768,6.538 12.348,6.314 L 13.8664,5.159 C 14.0032,5.054 14.0391,4.865 13.9528,4.711 L 12.5135,2.289 C 12.4272,2.135 12.2329,2.079 12.0745,2.135 l -1.7919,0.7 C 9.90842,2.555 9.50543,2.324 9.0664,2.149 L 8.79294,0.294 C 8.77135,0.126 8.62022,0 8.44031,0 H 5.56171 C 5.38181,0 5.23068,0.126 5.20909,0.294 L 4.93563,2.149 C 4.49665,2.324 4.09365,2.562 3.71943,2.835 l -1.7919,-0.7 C 1.76201,2.072 1.5749,2.135 1.48855,2.289 l -1.4393,2.422 c -0.093553,0.154 -0.050374,0.343 0.086356,0.448 l 1.5184,1.155 C 1.625226,6.538 1.603636,6.769 1.603636,7 c 0,0.231 0.02159,0.462 0.05037,0.686 l -1.5184,1.155 c -0.13673,0.105 -0.17271,0.294 -0.086356,0.448 l 1.4393,2.422 c 0.08635,0.154 0.28066,0.21 0.43898,0.154 l 1.7919,-0.7 c 0.37421,0.28 0.77721,0.511 1.2162,0.686 l 0.27346,1.855 C 5.23068,13.874 5.38181,14 5.56171,14 h 2.8786 c 0.17991,0 0.33104,-0.126 0.35263,-0.294 L 9.0664,11.851 c 0.43898,-0.175 0.84197,-0.413 1.2162,-0.686 l 1.7919,0.7 c 0.1655,0.063 0.3527,0 0.439,-0.154 L 13.9528,9.289 C 14.0391,9.135 14.0032,8.946 13.8664,8.841 Z M 7.0011,9.45 C 5.6122,9.45 4.4824,8.351 4.4824,7 4.4824,5.649 5.6122,4.55 7.0011,4.55 8.39,4.55 9.5198,5.649 9.5198,7 9.5198,8.351 8.39,9.45 7.0011,9.45 Z' /%3E %3Cpath id='m' d='M 0,0 H 16 V 12 H 0 Z' /%3E %3Cpath id='l' d='m 0,0 v -2 h -2 v 2 z m 16,0 h 2 v -2 h -2 z m 0,12 v 2 h 2 V 12 Z M 0,12 h -2 v 2 H 0 Z M 0,2 H 16 V -2 H 0 Z M 14,0 v 12 h 4 V 0 Z m 2,10 H 0 v 4 H 16 Z M 2,12 V 0 h -4 v 12 z' /%3E %3Cpath id='k' d='M 12,5.2941 H 8.5714 V 0 H 3.4285 V 5.2941 H -1e-4 l 6,6.1765 6,-6.1765 z M 0,13.2353 V 15 h 12 v -1.7647 z' /%3E %3Cpath id='j' d='M 9.3333,0 H 4.6666 V 1.5238 H 9.3333 Z M 6.2222,9.9048 H 7.7778 V 5.3334 H 6.2222 Z M 12.4678,4.8686 13.5722,3.7867 C 13.2378,3.39813 12.8722,3.03241 12.4756,2.7124 L 11.3711,3.7943 C 10.1656,2.84953 8.6489,2.2857 7,2.2857 3.1344,2.2857 0,5.3562 0,9.1429 0,12.9295 3.1267,16 7,16 10.8733,16 14,12.9295 14,9.1429 14,7.5277 13.4244,6.0419 12.4678,4.8686 Z M 7,14.4762 C 3.99,14.4762 1.5556,12.0914 1.5556,9.1429 1.5556,6.1943 3.99,3.8096 7,3.8096 c 3.01,0 5.4444,2.3848 5.4444,5.3333 0,2.9485 -2.4344,5.3333 -5.4444,5.3333 z' /%3E %3C/defs%3E %3Cg id='g3989' transform='matrix(0.03107656,0,0,0.03432918,271.52581,57.128037)' style='fill:%23ffffff'%3E %3Cg id='g3979' style='fill:%23ffffff'%3E %3Cpath style='fill:%23ffffff;stroke-width:0.03266241' d='m 273.49023,60.4375 c -1.07158,0 -1.96484,0.958273 -1.96484,2.169922 v 6.61914 c 0,1.216352 0.89727,2.167935 1.96484,2.167969 h 2.87305 c 0.52417,0 1.01765,-0.2246 1.39063,-0.634765 l 1,-1.103516 c 0.19059,-0.211639 0.45448,-0.333984 0.72656,-0.333984 0.27207,0 0.53829,0.122547 0.73047,0.335937 l 0.99804,1.101563 c 0.37212,0.409203 0.86646,0.634765 1.39063,0.634765 h 2.87305 c 1.07158,0 1.96484,-0.95632 1.96484,-2.167969 v -6.61914 c 0,-1.216352 -0.89727,-2.169922 -1.96484,-2.169922 z m 2.4961,3.308594 c 1.08295,0 1.96484,0.973618 1.96484,2.169922 0,1.196303 -0.88185,2.169921 -1.96484,2.169922 -1.08299,0 -1.96485,-0.973619 -1.96485,-2.169922 0,-1.196304 0.88189,-2.169922 1.96485,-2.169922 z m 6.99023,0 c 1.08296,0 1.96485,0.973618 1.96485,2.169922 0,1.196303 -0.88189,2.169922 -1.96485,2.169922 -1.08298,0 -1.96484,-0.973619 -1.96484,-2.169922 0,-1.196304 0.88189,-2.169922 1.96484,-2.169922 z' transform='matrix(32.178594,0,0,29.129737,-8737.3187,-1664.1247)' id='path3977' /%3E %3C/g%3E %3Cg id='g3983' style='fill:%23ffffff'/%3E %3Cg id='g3987' style='fill:%23ffffff'/%3E %3C/g%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 21.992188 A 6.9826789 6.9826789 0 0 0 310.04883 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 35.958984 A 6.9826789 6.9826789 0 0 0 324.01367 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 21.992188 z M 312.20703 27.580078 L 321.94336 27.642578 C 322.32865 27.645013 322.63647 27.956519 322.63281 28.341797 L 322.62109 29.603516 C 322.61743 29.988794 322.30326 30.297356 321.91797 30.294922 L 312.18164 30.232422 C 311.79635 30.229987 311.48853 29.918481 311.49219 29.533203 L 311.50391 28.271484 C 311.50757 27.886206 311.82174 27.577644 312.20703 27.580078 z ' id='path3997'/%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 59.992188 A 6.9826789 6.9826789 0 0 0 310.04883 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 73.958984 A 6.9826789 6.9826789 0 0 0 324.01367 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 59.992188 z M 316.49805 61.365234 L 317.76172 61.382812 C 318.14697 61.388692 318.45192 61.704576 318.44727 62.089844 L 318.4043 65.619141 L 321.94336 65.642578 C 322.32865 65.645013 322.63647 65.956519 322.63281 66.341797 L 322.62109 67.603516 C 322.61743 67.988794 322.30326 68.297356 321.91797 68.294922 L 318.37305 68.271484 L 318.33008 71.826172 C 318.32543 72.21144 318.0122 72.515645 317.62695 72.509766 L 316.36328 72.492188 C 315.97803 72.486309 315.67308 72.170424 315.67773 71.785156 L 315.7207 68.255859 L 312.18164 68.232422 C 311.79635 68.229987 311.48853 67.918481 311.49219 67.533203 L 311.50391 66.271484 C 311.50757 65.886206 311.82174 65.577644 312.20703 65.580078 L 315.75195 65.603516 L 315.79492 62.048828 C 315.79957 61.66356 316.1128 61.359355 316.49805 61.365234 z ' id='path3997-6'/%3E %3Cellipse style='fill:%23800000;fill-opacity:1;stroke-width:1.10310566' id='circle4073' cx='353.64172' cy='-28.97954' transform='scale(1,-1)' /%3E %3Cg id='g7787' transform='matrix(-0.02885349,0,0,-0.02885337,352.04486,75.172258)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cg id='g7731' transform='translate(-90.566882,42.049084)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cpath id='path7729' d='M 242.607,0 C 108.629,0 0.001,108.628 0.001,242.606 c 0,133.976 108.628,242.606 242.606,242.606 133.978,0 242.604,-108.631 242.604,-242.606 C 485.212,108.628 376.585,0 242.607,0 Z M 401.815,288.094 H 219.862 v 90.979 L 83.397,242.606 219.862,106.141 v 90.978 h 181.953 z' style='fill:%23ffffff;fill-opacity:1'/%3E %3C/g%3E %3Cg id='g7733' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7735' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7737' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7739' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7741' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7743' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7745' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7747' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7749' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7751' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7753' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7755' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7757' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7759' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7761' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3C/g%3E %3C/svg%3E") no-repeat;
+    position: absolute;
+    height: 24px;
+    width: 24px;
+    top: 1px;
+    left: 5px;
+    content: "";
+    opacity: 0.8;
+    -webkit-transition: opacity 0.3s ease-in-out;
+    -moz-transition: opacity 0.3s ease-in-out;
+    -ms-transition: opacity 0.3s ease-in-out;
+    -o-transition: opacity 0.3s ease-in-out;
+    transition: opacity 0.3s ease-in-out;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_play:before {
+    background-position: -15px -19px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_pause:before {
+    background-position: -15px -57px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_volume:before {
+    background-position: -52px -19px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_mute:before {
+    background-position: -52px -57px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_fullscreen:before {
+    background-position: -88px -19px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_fullscreen_exit:before {
+    background-position: -88px -57px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_video_source:before {
+    background-position: -122px -19px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_playback_rate:before {
+    background-position: -232px -19px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_download:before {
+    background-position: -194px -18px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_theatre:before {
+    background-position: -195px -56px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_subtitles:before {
+    background-position: -269px -19px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_cardboard:before {
+    background-position: -269px -56px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_skip_back:before {
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white' width='24px' height='24px'%3E %3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E %3Cpath d='M11.99 5V1l-5 5 5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6h-2c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8zm-1.1 11h-.85v-3.26l-1.01.31v-.69l1.77-.63h.09V16zm4.28-1.76c0 .32-.03.6-.1.82s-.17.42-.29.57-.28.26-.45.33-.37.1-.59.1-.41-.03-.59-.1-.33-.18-.46-.33-.23-.34-.3-.57-.11-.5-.11-.82v-.74c0-.32.03-.6.1-.82s.17-.42.29-.57.28-.26.45-.33.37-.1.59-.1.41.03.59.1.33.18.46.33.23.34.3.57.11.5.11.82v.74zm-.85-.86c0-.19-.01-.35-.04-.48s-.07-.23-.12-.31-.11-.14-.19-.17-.16-.05-.25-.05-.18.02-.25.05-.14.09-.19.17-.09.18-.12.31-.04.29-.04.48v.97c0 .19.01.35.04.48s.07.24.12.32.11.14.19.17.16.05.25.05.18-.02.25-.05.14-.09.19-.17.09-.19.11-.32.04-.29.04-.48v-.97z'/%3E %3C/svg%3E") no-repeat;
+    background-position: -2px -2px;
+}
+
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_skip_forward:before {
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' enable-background='new 0 0 24 24' viewBox='0 0 24 24' fill='white' width='24px' height='24px'%3E %3Cg%3E %3Crect fill='none' height='24' width='24'/%3E %3Crect fill='none' height='24' width='24'/%3E %3Crect fill='none' height='24' width='24'/%3E %3C/g%3E %3Cg%3E %3Cg/%3E %3Cg%3E %3Cpath d='M18,13c0,3.31-2.69,6-6,6s-6-2.69-6-6s2.69-6,6-6v4l5-5l-5-5v4c-4.42,0-8,3.58-8,8c0,4.42,3.58,8,8,8s8-3.58,8-8H18z'/%3E %3Cpolygon points='10.9,16 10.9,11.73 10.81,11.73 9.04,12.36 9.04,13.05 10.05,12.74 10.05,16'/%3E %3Cpath d='M14.32,11.78c-0.18-0.07-0.37-0.1-0.59-0.1s-0.41,0.03-0.59,0.1s-0.33,0.18-0.45,0.33s-0.23,0.34-0.29,0.57 s-0.1,0.5-0.1,0.82v0.74c0,0.32,0.04,0.6,0.11,0.82s0.17,0.42,0.3,0.57s0.28,0.26,0.46,0.33s0.37,0.1,0.59,0.1s0.41-0.03,0.59-0.1 s0.33-0.18,0.45-0.33s0.22-0.34,0.29-0.57s0.1-0.5,0.1-0.82V13.5c0-0.32-0.04-0.6-0.11-0.82s-0.17-0.42-0.3-0.57 S14.49,11.85,14.32,11.78z M14.33,14.35c0,0.19-0.01,0.35-0.04,0.48s-0.06,0.24-0.11,0.32s-0.11,0.14-0.19,0.17 s-0.16,0.05-0.25,0.05s-0.18-0.02-0.25-0.05s-0.14-0.09-0.19-0.17s-0.09-0.19-0.12-0.32s-0.04-0.29-0.04-0.48v-0.97 c0-0.19,0.01-0.35,0.04-0.48s0.06-0.23,0.12-0.31s0.11-0.14,0.19-0.17s0.16-0.05,0.25-0.05s0.18,0.02,0.25,0.05 s0.14,0.09,0.19,0.17s0.09,0.18,0.12,0.31s0.04,0.29,0.04,0.48V14.35z'/%3E %3C/g%3E %3C/g%3E %3C/svg%3E") no-repeat;
+    background-position: -2px -2px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_skip_back {
+    margin-left: 5px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_video_source:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_fullscreen_exit:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_fullscreen:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_mute:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_volume:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_pause:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_play:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_skip_back:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_skip_forward:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_playback_rate:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_download:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_theatre:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_subtitles:hover:before,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_cardboard:hover:before {
+    opacity: 1;
+}
+
+.fp_title {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    color: #ffffff;
+    font-size: 15px;
+    font-family: -apple-system, BlinkMacSystemFont, 'segoe ui', roboto, oxygen-sans, ubuntu, cantarell, 'helvetica neue', 'arial', sans-serif, 'apple color emoji', 'segoe ui emoji', 'segoe ui symbol';
+    font-weight: normal;
+    white-space: nowrap;
+}
+
+/* Pulse class and keyframe animation */
+.transform-active {
+    animation: flash 1s infinite;
+    display: inline-block !important;
+    opacity: 0;
+}
+
+@-webkit-keyframes flash {
+    0% {
+        opacity: 0.6;
+        -webkit-box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.5);
+    }
+    70% {
+        -webkit-box-shadow: 0 0 0 20px rgba(255, 255, 255, 0);
+    }
+    100% {
+        opacity: 0;
+        display: none;
+        -webkit-box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+    }
+}
+
+@keyframes flash {
+    0% {
+        opacity: 0.6;
+        -moz-box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.5);
+        box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.6);
+    }
+    70% {
+        -moz-box-shadow: 0 0 0 20px rgba(255, 255, 255, 0);
+        box-shadow: 0 0 0 20px rgba(255, 255, 255, 0);
+    }
+    100% {
+        opacity: 0;
+        display: none;
+        -moz-box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+        box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+    }
+}
+
+.fluid_nonLinear_top, .fluid_nonLinear_middle, .fluid_nonLinear_bottom {
+    flex-direction: column;
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    vertical-align: middle;
+    align-content: center;
+    border: 1px solid #777777;
+    position: absolute;
+    left: 50%;
+    margin-right: -50%;
+    background-color: rgba(0, 0, 0, 0.7);
+}
+
+.fluid_nonLinear_top {
+    top: 20px;
+    transform: translate(-50%);
+}
+
+.fluid_nonLinear_middle {
+    top: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.fluid_nonLinear_bottom {
+    bottom: 50px;
+    transform: translate(-50%);
+}
+
+.fluid_vpaidNonLinear_top, .fluid_vpaidNonLinear_middle, .fluid_vpaidNonLinear_bottom {
+    flex-direction: column;
+    align-items: center;
+    cursor: pointer;
+    vertical-align: middle;
+    align-content: center;
+    position: absolute;
+    display: flex;
+}
+
+.fluid_vpaidNonLinear_frame {
+    margin: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+.fluid_vpaidNonLinear_top {
+    top: 20px;
+}
+
+.fluid_vpaidNonLinear_middle {
+    top: 50%;
+}
+
+.fluid_vpaidNonLinear_bottom {
+    bottom: 50px;
+}
+
+.add_icon_clickthrough {
+    color: #F2C94C;
+    line-height: 18px;
+}
+
+.add_icon_clickthrough:before {
+    background: url("data:image/svg+xml,%3Csvg xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg' width='388.75' height='96' version='1.1' viewBox='0 0 388.75 96' id='svg63'%3E %3Cpath id='path4087' d='m 347.64062,35.959 a 6.9826789,6.9826789 0 0 0 6.98438,-6.984375 6.9826789,6.9826789 0 0 0 -6.98438,-6.982422 6.9826789,6.9826789 0 0 0 -6.98242,6.982422 6.9826789,6.9826789 0 0 0 6.98242,6.984375 z m 0,-2.476562 a 4.5078053,4.5078053 0 0 1 -4.50781,-4.507813 4.5078053,4.5078053 0 0 1 4.50781,-4.507812 4.5078053,4.5078053 0 0 1 4.50781,4.507812 4.5078053,4.5078053 0 0 1 -4.50781,4.507813 z' style='fill:%23ffffff;fill-opacity:1;stroke-width:1.70873225' /%3E %3Cpath style='fill:%23ffffff;fill-opacity:1;stroke-width:1.00886583' d='M 273.55469,22 C 272.69375,22 272,22.693749 272,23.554688 V 34.445312 C 272,35.306251 272.69375,36 273.55469,36 h 10.89062 C 285.30625,36 286,35.306251 286,34.445312 V 23.554688 C 286,22.693749 285.30625,22 284.44531,22 Z m 3.61133,4.541016 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z m 4.75,0 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z' id='rect7816' /%3E %3Cg transform='translate(-3702,106)' id='g44'%3E %3CclipPath id='q' style='clip-rule:evenodd'%3E %3Cpath d='m 3702,-106 h 272 v 96 h -272 z' id='path6' style='fill:%23ffffff'/%3E %3C/clipPath%3E %3Cg clip-path='url(%23q)' id='g42'%3E %3Cuse transform='translate(3757,-86)' xlink:href='%23o' id='use9' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3757,-48)' xlink:href='%23i' id='use11' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3830,-84)' xlink:href='%23h' id='use13' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-86)' xlink:href='%23g' id='use15' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-48)' xlink:href='%23f' id='use17' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-46)' xlink:href='%23e' id='use19' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3831,-46)' xlink:href='%23d' id='use21' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3865,-44)' xlink:href='%23c' id='use23' style='fill:%23f2c94c' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-84)' xlink:href='%23b' id='use25' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3866,-83)' xlink:href='%23a' id='use27' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-47)' xlink:href='%23n' id='use29' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cmask id='p'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23m' id='use31' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/mask%3E %3Cg mask='url(%23p)' id='g36'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23l' id='use34' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3Cuse transform='translate(3904,-85)' xlink:href='%23k' id='use38' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-85)' xlink:href='%23j' id='use40' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3C/g%3E %3Cdefs id='defs61'%3E %3Cpath id='o' d='m 0,5.5924 v 5.8152 H 3.7778 L 8.5,16.2537 V 0.7467 L 3.7778,5.5928 H 0 Z M 12.75,8.5 c 0,-1.7155 -0.9633,-3.1887 -2.3611,-3.9059 v 7.8021 C 11.7867,11.6887 12.75,10.2155 12.75,8.5 Z M 10.3889,0 v 1.9966 c 2.7294,0.83352 4.7222,3.431 4.7222,6.5034 0,3.0724 -1.9928,5.6699 -4.7222,6.5034 V 17 C 14.1761,16.118 17,12.6482 17,8.5 17,4.3518 14.1761,0.882 10.3889,0 Z' /%3E %3Cpath id='i' d='m 12.75,8.5 c 0,-1.6717 -0.9633,-3.1072 -2.3611,-3.8061 V 6.7811 L 12.7028,9.095 C 12.7311,8.90611 12.75,8.70778 12.75,8.5 Z m 2.3611,0 c 0,0.88778 -0.1889,1.7189 -0.51,2.4933 l 1.4261,1.4261 C 16.6506,11.2483 17,9.9167 17,8.5 17,4.4578 14.1761,1.0767 10.3889,0.2172 V 2.1628 C 13.1183,2.97502 15.1111,5.5061 15.1111,8.5 Z M 1.1991,0 -3e-4,1.1994 4.4669,5.6666 H -3e-4 v 5.6666 h 3.7778 l 4.7222,4.7223 V 9.6993 l 4.0139,4.0139 c -0.6328,0.4911 -1.3411,0.8784 -2.125,1.1145 v 1.9455 c 1.3033,-0.2927 2.4839,-0.8972 3.485,-1.7094 l 1.9267,1.9361 1.1994,-1.1994 -8.5,-8.5 L 1.1991,-1e-4 Z m 7.3006,0.94444 -1.9739,1.9739 1.9739,1.9739 z' /%3E %3Cpath id='h' d='M 12.444,0 H 1.555 C 0.69166,0 -6e-4,0.7 -6e-4,1.5556 v 10.889 c 0,0.8556 0.69222,1.5556 1.5556,1.5556 h 10.889 c 0.8556,0 1.5556,-0.7 1.5556,-1.5556 V 1.5556 C 13.9996,0.70004 13.2996,0 12.444,0 Z M 6.2218,9.3333 H 5.0551 V 7.7777 H 3.4995 V 9.3333 H 2.3328 V 4.6666 H 3.4995 V 6.611 H 5.0551 V 4.6666 H 6.2218 Z M 7.7774,4.6666 h 3.1111 c 0.4278,0 0.7778,0.35 0.7778,0.77777 v 3.1111 c 0,0.42777 -0.35,0.77777 -0.7778,0.77777 H 7.7774 v -4.6667 z m 1.1667,3.5 h 1.5556 V 5.8333 H 8.9441 Z' /%3E %3Cpath id='g' d='M 0,0 V 17 L 13,8.5 Z' /%3E %3Cpath id='f' d='M 0,17 H 4.3333 V 0 H 0 Z M 8.6667,0 V 17 H 13 V 0 Z' /%3E %3Cpath id='e' d='m 0,11 h 3 v 3 H 5 V 9 H 0 Z M 3,3 H 0 V 5 H 5 V 0 H 3 Z m 6,11 h 2 v -3 h 3 V 9 H 9 Z M 11,3 V 0 H 9 v 5 h 5 V 3 Z' /%3E %3Cpath id='d' d='M 0,12 8.5,6 0,0 Z M 10,0 v 12 h 2 V 0 Z' /%3E %3Cpath id='c' d='M 1.52,4.5 C 1.52,2.961 2.632,1.71 4,1.71 H 7.2 V 0 H 4 C 1.792,0 0,2.016 0,4.5 0,6.984 1.792,9 4,9 H 7.2 V 7.29 H 4 C 2.632,7.29 1.52,6.039 1.52,4.5 Z M 4.8,5.4 h 6.4 V 3.6 H 4.8 Z M 12,0 H 8.8 V 1.71 H 12 c 1.368,0 2.48,1.251 2.48,2.79 0,1.539 -1.112,2.79 -2.48,2.79 H 8.8 V 9 H 12 C 14.208,9 16,6.984 16,4.5 16,2.016 14.208,0 12,0 Z' /%3E %3Cpath id='b' d='M 2,9 H 0 v 5 H 5 V 12 H 2 Z M 0,5 H 2 V 2 H 5 V 0 H 0 Z m 12,7 H 9 v 2 h 5 V 9 H 12 Z M 9,0 v 2 h 3 v 3 h 2 V 0 Z' /%3E %3Cpath id='a' d='M 4.4546,8.7015 1.1137,5.2537 1e-4,6.403 4.4546,11 14,1.1492 12.8864,-1e-4 4.4546,8.7014 Z' /%3E %3Cpath id='n' d='M 12.348,7.686 C 12.3768,7.462 12.3984,7.238 12.3984,7 12.3984,6.762 12.3768,6.538 12.348,6.314 L 13.8664,5.159 C 14.0032,5.054 14.0391,4.865 13.9528,4.711 L 12.5135,2.289 C 12.4272,2.135 12.2329,2.079 12.0745,2.135 l -1.7919,0.7 C 9.90842,2.555 9.50543,2.324 9.0664,2.149 L 8.79294,0.294 C 8.77135,0.126 8.62022,0 8.44031,0 H 5.56171 C 5.38181,0 5.23068,0.126 5.20909,0.294 L 4.93563,2.149 C 4.49665,2.324 4.09365,2.562 3.71943,2.835 l -1.7919,-0.7 C 1.76201,2.072 1.5749,2.135 1.48855,2.289 l -1.4393,2.422 c -0.093553,0.154 -0.050374,0.343 0.086356,0.448 l 1.5184,1.155 C 1.625226,6.538 1.603636,6.769 1.603636,7 c 0,0.231 0.02159,0.462 0.05037,0.686 l -1.5184,1.155 c -0.13673,0.105 -0.17271,0.294 -0.086356,0.448 l 1.4393,2.422 c 0.08635,0.154 0.28066,0.21 0.43898,0.154 l 1.7919,-0.7 c 0.37421,0.28 0.77721,0.511 1.2162,0.686 l 0.27346,1.855 C 5.23068,13.874 5.38181,14 5.56171,14 h 2.8786 c 0.17991,0 0.33104,-0.126 0.35263,-0.294 L 9.0664,11.851 c 0.43898,-0.175 0.84197,-0.413 1.2162,-0.686 l 1.7919,0.7 c 0.1655,0.063 0.3527,0 0.439,-0.154 L 13.9528,9.289 C 14.0391,9.135 14.0032,8.946 13.8664,8.841 Z M 7.0011,9.45 C 5.6122,9.45 4.4824,8.351 4.4824,7 4.4824,5.649 5.6122,4.55 7.0011,4.55 8.39,4.55 9.5198,5.649 9.5198,7 9.5198,8.351 8.39,9.45 7.0011,9.45 Z' /%3E %3Cpath id='m' d='M 0,0 H 16 V 12 H 0 Z' /%3E %3Cpath id='l' d='m 0,0 v -2 h -2 v 2 z m 16,0 h 2 v -2 h -2 z m 0,12 v 2 h 2 V 12 Z M 0,12 h -2 v 2 H 0 Z M 0,2 H 16 V -2 H 0 Z M 14,0 v 12 h 4 V 0 Z m 2,10 H 0 v 4 H 16 Z M 2,12 V 0 h -4 v 12 z' /%3E %3Cpath id='k' d='M 12,5.2941 H 8.5714 V 0 H 3.4285 V 5.2941 H -1e-4 l 6,6.1765 6,-6.1765 z M 0,13.2353 V 15 h 12 v -1.7647 z' /%3E %3Cpath id='j' d='M 9.3333,0 H 4.6666 V 1.5238 H 9.3333 Z M 6.2222,9.9048 H 7.7778 V 5.3334 H 6.2222 Z M 12.4678,4.8686 13.5722,3.7867 C 13.2378,3.39813 12.8722,3.03241 12.4756,2.7124 L 11.3711,3.7943 C 10.1656,2.84953 8.6489,2.2857 7,2.2857 3.1344,2.2857 0,5.3562 0,9.1429 0,12.9295 3.1267,16 7,16 10.8733,16 14,12.9295 14,9.1429 14,7.5277 13.4244,6.0419 12.4678,4.8686 Z M 7,14.4762 C 3.99,14.4762 1.5556,12.0914 1.5556,9.1429 1.5556,6.1943 3.99,3.8096 7,3.8096 c 3.01,0 5.4444,2.3848 5.4444,5.3333 0,2.9485 -2.4344,5.3333 -5.4444,5.3333 z' /%3E %3C/defs%3E %3Cg id='g3989' transform='matrix(0.03107656,0,0,0.03432918,271.52581,57.128037)' style='fill:%23ffffff'%3E %3Cg id='g3979' style='fill:%23ffffff'%3E %3Cpath style='fill:%23ffffff;stroke-width:0.03266241' d='m 273.49023,60.4375 c -1.07158,0 -1.96484,0.958273 -1.96484,2.169922 v 6.61914 c 0,1.216352 0.89727,2.167935 1.96484,2.167969 h 2.87305 c 0.52417,0 1.01765,-0.2246 1.39063,-0.634765 l 1,-1.103516 c 0.19059,-0.211639 0.45448,-0.333984 0.72656,-0.333984 0.27207,0 0.53829,0.122547 0.73047,0.335937 l 0.99804,1.101563 c 0.37212,0.409203 0.86646,0.634765 1.39063,0.634765 h 2.87305 c 1.07158,0 1.96484,-0.95632 1.96484,-2.167969 v -6.61914 c 0,-1.216352 -0.89727,-2.169922 -1.96484,-2.169922 z m 2.4961,3.308594 c 1.08295,0 1.96484,0.973618 1.96484,2.169922 0,1.196303 -0.88185,2.169921 -1.96484,2.169922 -1.08299,0 -1.96485,-0.973619 -1.96485,-2.169922 0,-1.196304 0.88189,-2.169922 1.96485,-2.169922 z m 6.99023,0 c 1.08296,0 1.96485,0.973618 1.96485,2.169922 0,1.196303 -0.88189,2.169922 -1.96485,2.169922 -1.08298,0 -1.96484,-0.973619 -1.96484,-2.169922 0,-1.196304 0.88189,-2.169922 1.96484,-2.169922 z' transform='matrix(32.178594,0,0,29.129737,-8737.3187,-1664.1247)' id='path3977' /%3E %3C/g%3E %3Cg id='g3983' style='fill:%23ffffff'/%3E %3Cg id='g3987' style='fill:%23ffffff'/%3E %3C/g%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 21.992188 A 6.9826789 6.9826789 0 0 0 310.04883 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 35.958984 A 6.9826789 6.9826789 0 0 0 324.01367 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 21.992188 z M 312.20703 27.580078 L 321.94336 27.642578 C 322.32865 27.645013 322.63647 27.956519 322.63281 28.341797 L 322.62109 29.603516 C 322.61743 29.988794 322.30326 30.297356 321.91797 30.294922 L 312.18164 30.232422 C 311.79635 30.229987 311.48853 29.918481 311.49219 29.533203 L 311.50391 28.271484 C 311.50757 27.886206 311.82174 27.577644 312.20703 27.580078 z ' id='path3997'/%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 59.992188 A 6.9826789 6.9826789 0 0 0 310.04883 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 73.958984 A 6.9826789 6.9826789 0 0 0 324.01367 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 59.992188 z M 316.49805 61.365234 L 317.76172 61.382812 C 318.14697 61.388692 318.45192 61.704576 318.44727 62.089844 L 318.4043 65.619141 L 321.94336 65.642578 C 322.32865 65.645013 322.63647 65.956519 322.63281 66.341797 L 322.62109 67.603516 C 322.61743 67.988794 322.30326 68.297356 321.91797 68.294922 L 318.37305 68.271484 L 318.33008 71.826172 C 318.32543 72.21144 318.0122 72.515645 317.62695 72.509766 L 316.36328 72.492188 C 315.97803 72.486309 315.67308 72.170424 315.67773 71.785156 L 315.7207 68.255859 L 312.18164 68.232422 C 311.79635 68.229987 311.48853 67.918481 311.49219 67.533203 L 311.50391 66.271484 C 311.50757 65.886206 311.82174 65.577644 312.20703 65.580078 L 315.75195 65.603516 L 315.79492 62.048828 C 315.79957 61.66356 316.1128 61.359355 316.49805 61.365234 z ' id='path3997-6'/%3E %3Cellipse style='fill:%23800000;fill-opacity:1;stroke-width:1.10310566' id='circle4073' cx='353.64172' cy='-28.97954' transform='scale(1,-1)' /%3E %3Cg id='g7787' transform='matrix(-0.02885349,0,0,-0.02885337,352.04486,75.172258)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cg id='g7731' transform='translate(-90.566882,42.049084)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cpath id='path7729' d='M 242.607,0 C 108.629,0 0.001,108.628 0.001,242.606 c 0,133.976 108.628,242.606 242.606,242.606 133.978,0 242.604,-108.631 242.604,-242.606 C 485.212,108.628 376.585,0 242.607,0 Z M 401.815,288.094 H 219.862 v 90.979 L 83.397,242.606 219.862,106.141 v 90.978 h 181.953 z' style='fill:%23ffffff;fill-opacity:1'/%3E %3C/g%3E %3Cg id='g7733' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7735' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7737' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7739' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7741' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7743' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7745' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7747' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7749' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7751' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7753' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7755' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7757' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7759' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7761' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3C/g%3E %3C/svg%3E") no-repeat;
+    height: 18px;
+    width: 18px;
+    top: 30px;
+    padding: 1px 22px 0 0;
+    content: "";
+    background-position: -162px -57px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_theatre,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_playback_rate,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_video_source,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_download,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_subtitles,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_cardboard {
+    float: right;
+    padding-right: 5px;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_theatre,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_playback_rate,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_video_source,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_download,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_subtitles,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_button.fluid_button_cardboard {
+    display: none;
+}
+
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_subtitles .fluid_subtitles_list,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_button_video_source .fluid_video_sources_list,
+.fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_video_playback_rates {
+    z-index: 888888 !important;
+    opacity: 0.9 !important;
+}
+
+.fluid_video_playback_rates_item {
+    padding: 9px 25px 9px 25px;
+    line-height: 15px;
+    text-align: center;
+}
+
+.fluid_theatre_mode {
+    position: fixed;
+    float: left;
+    top: 0;
+    z-index: 10;
+    box-shadow: 0px 15px 25px rgba(0, 0, 0, 0.8);
+}
+
+.source_button_icon {
+    background: url("data:image/svg+xml,%3Csvg xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg' width='388.75' height='96' version='1.1' viewBox='0 0 388.75 96' id='svg63'%3E %3Cpath id='path4087' d='m 347.64062,35.959 a 6.9826789,6.9826789 0 0 0 6.98438,-6.984375 6.9826789,6.9826789 0 0 0 -6.98438,-6.982422 6.9826789,6.9826789 0 0 0 -6.98242,6.982422 6.9826789,6.9826789 0 0 0 6.98242,6.984375 z m 0,-2.476562 a 4.5078053,4.5078053 0 0 1 -4.50781,-4.507813 4.5078053,4.5078053 0 0 1 4.50781,-4.507812 4.5078053,4.5078053 0 0 1 4.50781,4.507812 4.5078053,4.5078053 0 0 1 -4.50781,4.507813 z' style='fill:%23ffffff;fill-opacity:1;stroke-width:1.70873225' /%3E %3Cpath style='fill:%23ffffff;fill-opacity:1;stroke-width:1.00886583' d='M 273.55469,22 C 272.69375,22 272,22.693749 272,23.554688 V 34.445312 C 272,35.306251 272.69375,36 273.55469,36 h 10.89062 C 285.30625,36 286,35.306251 286,34.445312 V 23.554688 C 286,22.693749 285.30625,22 284.44531,22 Z m 3.61133,4.541016 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z m 4.75,0 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z' id='rect7816' /%3E %3Cg transform='translate(-3702,106)' id='g44'%3E %3CclipPath id='q' style='clip-rule:evenodd'%3E %3Cpath d='m 3702,-106 h 272 v 96 h -272 z' id='path6' style='fill:%23ffffff'/%3E %3C/clipPath%3E %3Cg clip-path='url(%23q)' id='g42'%3E %3Cuse transform='translate(3757,-86)' xlink:href='%23o' id='use9' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3757,-48)' xlink:href='%23i' id='use11' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3830,-84)' xlink:href='%23h' id='use13' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-86)' xlink:href='%23g' id='use15' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-48)' xlink:href='%23f' id='use17' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-46)' xlink:href='%23e' id='use19' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3831,-46)' xlink:href='%23d' id='use21' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3865,-44)' xlink:href='%23c' id='use23' style='fill:%23f2c94c' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-84)' xlink:href='%23b' id='use25' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3866,-83)' xlink:href='%23a' id='use27' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-47)' xlink:href='%23n' id='use29' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cmask id='p'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23m' id='use31' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/mask%3E %3Cg mask='url(%23p)' id='g36'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23l' id='use34' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3Cuse transform='translate(3904,-85)' xlink:href='%23k' id='use38' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-85)' xlink:href='%23j' id='use40' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3C/g%3E %3Cdefs id='defs61'%3E %3Cpath id='o' d='m 0,5.5924 v 5.8152 H 3.7778 L 8.5,16.2537 V 0.7467 L 3.7778,5.5928 H 0 Z M 12.75,8.5 c 0,-1.7155 -0.9633,-3.1887 -2.3611,-3.9059 v 7.8021 C 11.7867,11.6887 12.75,10.2155 12.75,8.5 Z M 10.3889,0 v 1.9966 c 2.7294,0.83352 4.7222,3.431 4.7222,6.5034 0,3.0724 -1.9928,5.6699 -4.7222,6.5034 V 17 C 14.1761,16.118 17,12.6482 17,8.5 17,4.3518 14.1761,0.882 10.3889,0 Z' /%3E %3Cpath id='i' d='m 12.75,8.5 c 0,-1.6717 -0.9633,-3.1072 -2.3611,-3.8061 V 6.7811 L 12.7028,9.095 C 12.7311,8.90611 12.75,8.70778 12.75,8.5 Z m 2.3611,0 c 0,0.88778 -0.1889,1.7189 -0.51,2.4933 l 1.4261,1.4261 C 16.6506,11.2483 17,9.9167 17,8.5 17,4.4578 14.1761,1.0767 10.3889,0.2172 V 2.1628 C 13.1183,2.97502 15.1111,5.5061 15.1111,8.5 Z M 1.1991,0 -3e-4,1.1994 4.4669,5.6666 H -3e-4 v 5.6666 h 3.7778 l 4.7222,4.7223 V 9.6993 l 4.0139,4.0139 c -0.6328,0.4911 -1.3411,0.8784 -2.125,1.1145 v 1.9455 c 1.3033,-0.2927 2.4839,-0.8972 3.485,-1.7094 l 1.9267,1.9361 1.1994,-1.1994 -8.5,-8.5 L 1.1991,-1e-4 Z m 7.3006,0.94444 -1.9739,1.9739 1.9739,1.9739 z' /%3E %3Cpath id='h' d='M 12.444,0 H 1.555 C 0.69166,0 -6e-4,0.7 -6e-4,1.5556 v 10.889 c 0,0.8556 0.69222,1.5556 1.5556,1.5556 h 10.889 c 0.8556,0 1.5556,-0.7 1.5556,-1.5556 V 1.5556 C 13.9996,0.70004 13.2996,0 12.444,0 Z M 6.2218,9.3333 H 5.0551 V 7.7777 H 3.4995 V 9.3333 H 2.3328 V 4.6666 H 3.4995 V 6.611 H 5.0551 V 4.6666 H 6.2218 Z M 7.7774,4.6666 h 3.1111 c 0.4278,0 0.7778,0.35 0.7778,0.77777 v 3.1111 c 0,0.42777 -0.35,0.77777 -0.7778,0.77777 H 7.7774 v -4.6667 z m 1.1667,3.5 h 1.5556 V 5.8333 H 8.9441 Z' /%3E %3Cpath id='g' d='M 0,0 V 17 L 13,8.5 Z' /%3E %3Cpath id='f' d='M 0,17 H 4.3333 V 0 H 0 Z M 8.6667,0 V 17 H 13 V 0 Z' /%3E %3Cpath id='e' d='m 0,11 h 3 v 3 H 5 V 9 H 0 Z M 3,3 H 0 V 5 H 5 V 0 H 3 Z m 6,11 h 2 v -3 h 3 V 9 H 9 Z M 11,3 V 0 H 9 v 5 h 5 V 3 Z' /%3E %3Cpath id='d' d='M 0,12 8.5,6 0,0 Z M 10,0 v 12 h 2 V 0 Z' /%3E %3Cpath id='c' d='M 1.52,4.5 C 1.52,2.961 2.632,1.71 4,1.71 H 7.2 V 0 H 4 C 1.792,0 0,2.016 0,4.5 0,6.984 1.792,9 4,9 H 7.2 V 7.29 H 4 C 2.632,7.29 1.52,6.039 1.52,4.5 Z M 4.8,5.4 h 6.4 V 3.6 H 4.8 Z M 12,0 H 8.8 V 1.71 H 12 c 1.368,0 2.48,1.251 2.48,2.79 0,1.539 -1.112,2.79 -2.48,2.79 H 8.8 V 9 H 12 C 14.208,9 16,6.984 16,4.5 16,2.016 14.208,0 12,0 Z' /%3E %3Cpath id='b' d='M 2,9 H 0 v 5 H 5 V 12 H 2 Z M 0,5 H 2 V 2 H 5 V 0 H 0 Z m 12,7 H 9 v 2 h 5 V 9 H 12 Z M 9,0 v 2 h 3 v 3 h 2 V 0 Z' /%3E %3Cpath id='a' d='M 4.4546,8.7015 1.1137,5.2537 1e-4,6.403 4.4546,11 14,1.1492 12.8864,-1e-4 4.4546,8.7014 Z' /%3E %3Cpath id='n' d='M 12.348,7.686 C 12.3768,7.462 12.3984,7.238 12.3984,7 12.3984,6.762 12.3768,6.538 12.348,6.314 L 13.8664,5.159 C 14.0032,5.054 14.0391,4.865 13.9528,4.711 L 12.5135,2.289 C 12.4272,2.135 12.2329,2.079 12.0745,2.135 l -1.7919,0.7 C 9.90842,2.555 9.50543,2.324 9.0664,2.149 L 8.79294,0.294 C 8.77135,0.126 8.62022,0 8.44031,0 H 5.56171 C 5.38181,0 5.23068,0.126 5.20909,0.294 L 4.93563,2.149 C 4.49665,2.324 4.09365,2.562 3.71943,2.835 l -1.7919,-0.7 C 1.76201,2.072 1.5749,2.135 1.48855,2.289 l -1.4393,2.422 c -0.093553,0.154 -0.050374,0.343 0.086356,0.448 l 1.5184,1.155 C 1.625226,6.538 1.603636,6.769 1.603636,7 c 0,0.231 0.02159,0.462 0.05037,0.686 l -1.5184,1.155 c -0.13673,0.105 -0.17271,0.294 -0.086356,0.448 l 1.4393,2.422 c 0.08635,0.154 0.28066,0.21 0.43898,0.154 l 1.7919,-0.7 c 0.37421,0.28 0.77721,0.511 1.2162,0.686 l 0.27346,1.855 C 5.23068,13.874 5.38181,14 5.56171,14 h 2.8786 c 0.17991,0 0.33104,-0.126 0.35263,-0.294 L 9.0664,11.851 c 0.43898,-0.175 0.84197,-0.413 1.2162,-0.686 l 1.7919,0.7 c 0.1655,0.063 0.3527,0 0.439,-0.154 L 13.9528,9.289 C 14.0391,9.135 14.0032,8.946 13.8664,8.841 Z M 7.0011,9.45 C 5.6122,9.45 4.4824,8.351 4.4824,7 4.4824,5.649 5.6122,4.55 7.0011,4.55 8.39,4.55 9.5198,5.649 9.5198,7 9.5198,8.351 8.39,9.45 7.0011,9.45 Z' /%3E %3Cpath id='m' d='M 0,0 H 16 V 12 H 0 Z' /%3E %3Cpath id='l' d='m 0,0 v -2 h -2 v 2 z m 16,0 h 2 v -2 h -2 z m 0,12 v 2 h 2 V 12 Z M 0,12 h -2 v 2 H 0 Z M 0,2 H 16 V -2 H 0 Z M 14,0 v 12 h 4 V 0 Z m 2,10 H 0 v 4 H 16 Z M 2,12 V 0 h -4 v 12 z' /%3E %3Cpath id='k' d='M 12,5.2941 H 8.5714 V 0 H 3.4285 V 5.2941 H -1e-4 l 6,6.1765 6,-6.1765 z M 0,13.2353 V 15 h 12 v -1.7647 z' /%3E %3Cpath id='j' d='M 9.3333,0 H 4.6666 V 1.5238 H 9.3333 Z M 6.2222,9.9048 H 7.7778 V 5.3334 H 6.2222 Z M 12.4678,4.8686 13.5722,3.7867 C 13.2378,3.39813 12.8722,3.03241 12.4756,2.7124 L 11.3711,3.7943 C 10.1656,2.84953 8.6489,2.2857 7,2.2857 3.1344,2.2857 0,5.3562 0,9.1429 0,12.9295 3.1267,16 7,16 10.8733,16 14,12.9295 14,9.1429 14,7.5277 13.4244,6.0419 12.4678,4.8686 Z M 7,14.4762 C 3.99,14.4762 1.5556,12.0914 1.5556,9.1429 1.5556,6.1943 3.99,3.8096 7,3.8096 c 3.01,0 5.4444,2.3848 5.4444,5.3333 0,2.9485 -2.4344,5.3333 -5.4444,5.3333 z' /%3E %3C/defs%3E %3Cg id='g3989' transform='matrix(0.03107656,0,0,0.03432918,271.52581,57.128037)' style='fill:%23ffffff'%3E %3Cg id='g3979' style='fill:%23ffffff'%3E %3Cpath style='fill:%23ffffff;stroke-width:0.03266241' d='m 273.49023,60.4375 c -1.07158,0 -1.96484,0.958273 -1.96484,2.169922 v 6.61914 c 0,1.216352 0.89727,2.167935 1.96484,2.167969 h 2.87305 c 0.52417,0 1.01765,-0.2246 1.39063,-0.634765 l 1,-1.103516 c 0.19059,-0.211639 0.45448,-0.333984 0.72656,-0.333984 0.27207,0 0.53829,0.122547 0.73047,0.335937 l 0.99804,1.101563 c 0.37212,0.409203 0.86646,0.634765 1.39063,0.634765 h 2.87305 c 1.07158,0 1.96484,-0.95632 1.96484,-2.167969 v -6.61914 c 0,-1.216352 -0.89727,-2.169922 -1.96484,-2.169922 z m 2.4961,3.308594 c 1.08295,0 1.96484,0.973618 1.96484,2.169922 0,1.196303 -0.88185,2.169921 -1.96484,2.169922 -1.08299,0 -1.96485,-0.973619 -1.96485,-2.169922 0,-1.196304 0.88189,-2.169922 1.96485,-2.169922 z m 6.99023,0 c 1.08296,0 1.96485,0.973618 1.96485,2.169922 0,1.196303 -0.88189,2.169922 -1.96485,2.169922 -1.08298,0 -1.96484,-0.973619 -1.96484,-2.169922 0,-1.196304 0.88189,-2.169922 1.96484,-2.169922 z' transform='matrix(32.178594,0,0,29.129737,-8737.3187,-1664.1247)' id='path3977' /%3E %3C/g%3E %3Cg id='g3983' style='fill:%23ffffff'/%3E %3Cg id='g3987' style='fill:%23ffffff'/%3E %3C/g%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 21.992188 A 6.9826789 6.9826789 0 0 0 310.04883 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 35.958984 A 6.9826789 6.9826789 0 0 0 324.01367 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 21.992188 z M 312.20703 27.580078 L 321.94336 27.642578 C 322.32865 27.645013 322.63647 27.956519 322.63281 28.341797 L 322.62109 29.603516 C 322.61743 29.988794 322.30326 30.297356 321.91797 30.294922 L 312.18164 30.232422 C 311.79635 30.229987 311.48853 29.918481 311.49219 29.533203 L 311.50391 28.271484 C 311.50757 27.886206 311.82174 27.577644 312.20703 27.580078 z ' id='path3997'/%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 59.992188 A 6.9826789 6.9826789 0 0 0 310.04883 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 73.958984 A 6.9826789 6.9826789 0 0 0 324.01367 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 59.992188 z M 316.49805 61.365234 L 317.76172 61.382812 C 318.14697 61.388692 318.45192 61.704576 318.44727 62.089844 L 318.4043 65.619141 L 321.94336 65.642578 C 322.32865 65.645013 322.63647 65.956519 322.63281 66.341797 L 322.62109 67.603516 C 322.61743 67.988794 322.30326 68.297356 321.91797 68.294922 L 318.37305 68.271484 L 318.33008 71.826172 C 318.32543 72.21144 318.0122 72.515645 317.62695 72.509766 L 316.36328 72.492188 C 315.97803 72.486309 315.67308 72.170424 315.67773 71.785156 L 315.7207 68.255859 L 312.18164 68.232422 C 311.79635 68.229987 311.48853 67.918481 311.49219 67.533203 L 311.50391 66.271484 C 311.50757 65.886206 311.82174 65.577644 312.20703 65.580078 L 315.75195 65.603516 L 315.79492 62.048828 C 315.79957 61.66356 316.1128 61.359355 316.49805 61.365234 z ' id='path3997-6'/%3E %3Cellipse style='fill:%23800000;fill-opacity:1;stroke-width:1.10310566' id='circle4073' cx='353.64172' cy='-28.97954' transform='scale(1,-1)' /%3E %3Cg id='g7787' transform='matrix(-0.02885349,0,0,-0.02885337,352.04486,75.172258)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cg id='g7731' transform='translate(-90.566882,42.049084)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cpath id='path7729' d='M 242.607,0 C 108.629,0 0.001,108.628 0.001,242.606 c 0,133.976 108.628,242.606 242.606,242.606 133.978,0 242.604,-108.631 242.604,-242.606 C 485.212,108.628 376.585,0 242.607,0 Z M 401.815,288.094 H 219.862 v 90.979 L 83.397,242.606 219.862,106.141 v 90.978 h 181.953 z' style='fill:%23ffffff;fill-opacity:1'/%3E %3C/g%3E %3Cg id='g7733' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7735' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7737' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7739' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7741' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7743' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7745' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7747' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7749' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7751' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7753' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7755' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7757' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7759' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7761' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3C/g%3E %3C/svg%3E") no-repeat;
+    float: left;
+    cursor: pointer;
+    height: 18px;
+    width: 18px;
+    background-position: -164px -21px;
+    opacity: 0;
+}
+
+.subtitle_button_icon {
+    background: url("data:image/svg+xml,%3Csvg xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg' width='388.75' height='96' version='1.1' viewBox='0 0 388.75 96' id='svg63'%3E %3Cpath id='path4087' d='m 347.64062,35.959 a 6.9826789,6.9826789 0 0 0 6.98438,-6.984375 6.9826789,6.9826789 0 0 0 -6.98438,-6.982422 6.9826789,6.9826789 0 0 0 -6.98242,6.982422 6.9826789,6.9826789 0 0 0 6.98242,6.984375 z m 0,-2.476562 a 4.5078053,4.5078053 0 0 1 -4.50781,-4.507813 4.5078053,4.5078053 0 0 1 4.50781,-4.507812 4.5078053,4.5078053 0 0 1 4.50781,4.507812 4.5078053,4.5078053 0 0 1 -4.50781,4.507813 z' style='fill:%23ffffff;fill-opacity:1;stroke-width:1.70873225' /%3E %3Cpath style='fill:%23ffffff;fill-opacity:1;stroke-width:1.00886583' d='M 273.55469,22 C 272.69375,22 272,22.693749 272,23.554688 V 34.445312 C 272,35.306251 272.69375,36 273.55469,36 h 10.89062 C 285.30625,36 286,35.306251 286,34.445312 V 23.554688 C 286,22.693749 285.30625,22 284.44531,22 Z m 3.61133,4.541016 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z m 4.75,0 c 0.22916,0 0.45442,0.02083 0.67578,0.0625 0.22396,0.03906 0.44661,0.09896 0.66797,0.179687 v 1.140625 c -0.19011,-0.130208 -0.38151,-0.226562 -0.57422,-0.289062 -0.19011,-0.0625 -0.38802,-0.09375 -0.59375,-0.09375 -0.39063,0 -0.69532,0.114583 -0.91407,0.34375 -0.21614,0.226562 -0.32421,0.54427 -0.32421,0.953125 0,0.408854 0.10807,0.727864 0.32421,0.957031 0.21875,0.226562 0.52344,0.339844 0.91407,0.339844 0.21875,0 0.42578,-0.03255 0.62109,-0.09766 0.19792,-0.0651 0.38021,-0.161458 0.54688,-0.289062 v 1.144531 c -0.21875,0.08073 -0.44141,0.140625 -0.66797,0.179688 -0.22396,0.04167 -0.44922,0.0625 -0.67578,0.0625 -0.78907,0 -1.40625,-0.201823 -1.85157,-0.605469 -0.44531,-0.40625 -0.66797,-0.970052 -0.66797,-1.691406 0,-0.721355 0.22266,-1.283855 0.66797,-1.6875 0.44532,-0.40625 1.0625,-0.609375 1.85157,-0.609375 z' id='rect7816' /%3E %3Cg transform='translate(-3702,106)' id='g44'%3E %3CclipPath id='q' style='clip-rule:evenodd'%3E %3Cpath d='m 3702,-106 h 272 v 96 h -272 z' id='path6' style='fill:%23ffffff'/%3E %3C/clipPath%3E %3Cg clip-path='url(%23q)' id='g42'%3E %3Cuse transform='translate(3757,-86)' xlink:href='%23o' id='use9' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3757,-48)' xlink:href='%23i' id='use11' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3830,-84)' xlink:href='%23h' id='use13' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-86)' xlink:href='%23g' id='use15' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3723,-48)' xlink:href='%23f' id='use17' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-46)' xlink:href='%23e' id='use19' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3831,-46)' xlink:href='%23d' id='use21' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3865,-44)' xlink:href='%23c' id='use23' style='fill:%23f2c94c' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3795,-84)' xlink:href='%23b' id='use25' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3866,-83)' xlink:href='%23a' id='use27' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-47)' xlink:href='%23n' id='use29' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cmask id='p'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23m' id='use31' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/mask%3E %3Cg mask='url(%23p)' id='g36'%3E %3Cuse transform='translate(3902,-46)' xlink:href='%23l' id='use34' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3Cuse transform='translate(3904,-85)' xlink:href='%23k' id='use38' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3Cuse transform='translate(3939,-85)' xlink:href='%23j' id='use40' style='fill:%23ffffff' x='0' y='0' width='100%25' height='100%25'/%3E %3C/g%3E %3C/g%3E %3Cdefs id='defs61'%3E %3Cpath id='o' d='m 0,5.5924 v 5.8152 H 3.7778 L 8.5,16.2537 V 0.7467 L 3.7778,5.5928 H 0 Z M 12.75,8.5 c 0,-1.7155 -0.9633,-3.1887 -2.3611,-3.9059 v 7.8021 C 11.7867,11.6887 12.75,10.2155 12.75,8.5 Z M 10.3889,0 v 1.9966 c 2.7294,0.83352 4.7222,3.431 4.7222,6.5034 0,3.0724 -1.9928,5.6699 -4.7222,6.5034 V 17 C 14.1761,16.118 17,12.6482 17,8.5 17,4.3518 14.1761,0.882 10.3889,0 Z' /%3E %3Cpath id='i' d='m 12.75,8.5 c 0,-1.6717 -0.9633,-3.1072 -2.3611,-3.8061 V 6.7811 L 12.7028,9.095 C 12.7311,8.90611 12.75,8.70778 12.75,8.5 Z m 2.3611,0 c 0,0.88778 -0.1889,1.7189 -0.51,2.4933 l 1.4261,1.4261 C 16.6506,11.2483 17,9.9167 17,8.5 17,4.4578 14.1761,1.0767 10.3889,0.2172 V 2.1628 C 13.1183,2.97502 15.1111,5.5061 15.1111,8.5 Z M 1.1991,0 -3e-4,1.1994 4.4669,5.6666 H -3e-4 v 5.6666 h 3.7778 l 4.7222,4.7223 V 9.6993 l 4.0139,4.0139 c -0.6328,0.4911 -1.3411,0.8784 -2.125,1.1145 v 1.9455 c 1.3033,-0.2927 2.4839,-0.8972 3.485,-1.7094 l 1.9267,1.9361 1.1994,-1.1994 -8.5,-8.5 L 1.1991,-1e-4 Z m 7.3006,0.94444 -1.9739,1.9739 1.9739,1.9739 z' /%3E %3Cpath id='h' d='M 12.444,0 H 1.555 C 0.69166,0 -6e-4,0.7 -6e-4,1.5556 v 10.889 c 0,0.8556 0.69222,1.5556 1.5556,1.5556 h 10.889 c 0.8556,0 1.5556,-0.7 1.5556,-1.5556 V 1.5556 C 13.9996,0.70004 13.2996,0 12.444,0 Z M 6.2218,9.3333 H 5.0551 V 7.7777 H 3.4995 V 9.3333 H 2.3328 V 4.6666 H 3.4995 V 6.611 H 5.0551 V 4.6666 H 6.2218 Z M 7.7774,4.6666 h 3.1111 c 0.4278,0 0.7778,0.35 0.7778,0.77777 v 3.1111 c 0,0.42777 -0.35,0.77777 -0.7778,0.77777 H 7.7774 v -4.6667 z m 1.1667,3.5 h 1.5556 V 5.8333 H 8.9441 Z' /%3E %3Cpath id='g' d='M 0,0 V 17 L 13,8.5 Z' /%3E %3Cpath id='f' d='M 0,17 H 4.3333 V 0 H 0 Z M 8.6667,0 V 17 H 13 V 0 Z' /%3E %3Cpath id='e' d='m 0,11 h 3 v 3 H 5 V 9 H 0 Z M 3,3 H 0 V 5 H 5 V 0 H 3 Z m 6,11 h 2 v -3 h 3 V 9 H 9 Z M 11,3 V 0 H 9 v 5 h 5 V 3 Z' /%3E %3Cpath id='d' d='M 0,12 8.5,6 0,0 Z M 10,0 v 12 h 2 V 0 Z' /%3E %3Cpath id='c' d='M 1.52,4.5 C 1.52,2.961 2.632,1.71 4,1.71 H 7.2 V 0 H 4 C 1.792,0 0,2.016 0,4.5 0,6.984 1.792,9 4,9 H 7.2 V 7.29 H 4 C 2.632,7.29 1.52,6.039 1.52,4.5 Z M 4.8,5.4 h 6.4 V 3.6 H 4.8 Z M 12,0 H 8.8 V 1.71 H 12 c 1.368,0 2.48,1.251 2.48,2.79 0,1.539 -1.112,2.79 -2.48,2.79 H 8.8 V 9 H 12 C 14.208,9 16,6.984 16,4.5 16,2.016 14.208,0 12,0 Z' /%3E %3Cpath id='b' d='M 2,9 H 0 v 5 H 5 V 12 H 2 Z M 0,5 H 2 V 2 H 5 V 0 H 0 Z m 12,7 H 9 v 2 h 5 V 9 H 12 Z M 9,0 v 2 h 3 v 3 h 2 V 0 Z' /%3E %3Cpath id='a' d='M 4.4546,8.7015 1.1137,5.2537 1e-4,6.403 4.4546,11 14,1.1492 12.8864,-1e-4 4.4546,8.7014 Z' /%3E %3Cpath id='n' d='M 12.348,7.686 C 12.3768,7.462 12.3984,7.238 12.3984,7 12.3984,6.762 12.3768,6.538 12.348,6.314 L 13.8664,5.159 C 14.0032,5.054 14.0391,4.865 13.9528,4.711 L 12.5135,2.289 C 12.4272,2.135 12.2329,2.079 12.0745,2.135 l -1.7919,0.7 C 9.90842,2.555 9.50543,2.324 9.0664,2.149 L 8.79294,0.294 C 8.77135,0.126 8.62022,0 8.44031,0 H 5.56171 C 5.38181,0 5.23068,0.126 5.20909,0.294 L 4.93563,2.149 C 4.49665,2.324 4.09365,2.562 3.71943,2.835 l -1.7919,-0.7 C 1.76201,2.072 1.5749,2.135 1.48855,2.289 l -1.4393,2.422 c -0.093553,0.154 -0.050374,0.343 0.086356,0.448 l 1.5184,1.155 C 1.625226,6.538 1.603636,6.769 1.603636,7 c 0,0.231 0.02159,0.462 0.05037,0.686 l -1.5184,1.155 c -0.13673,0.105 -0.17271,0.294 -0.086356,0.448 l 1.4393,2.422 c 0.08635,0.154 0.28066,0.21 0.43898,0.154 l 1.7919,-0.7 c 0.37421,0.28 0.77721,0.511 1.2162,0.686 l 0.27346,1.855 C 5.23068,13.874 5.38181,14 5.56171,14 h 2.8786 c 0.17991,0 0.33104,-0.126 0.35263,-0.294 L 9.0664,11.851 c 0.43898,-0.175 0.84197,-0.413 1.2162,-0.686 l 1.7919,0.7 c 0.1655,0.063 0.3527,0 0.439,-0.154 L 13.9528,9.289 C 14.0391,9.135 14.0032,8.946 13.8664,8.841 Z M 7.0011,9.45 C 5.6122,9.45 4.4824,8.351 4.4824,7 4.4824,5.649 5.6122,4.55 7.0011,4.55 8.39,4.55 9.5198,5.649 9.5198,7 9.5198,8.351 8.39,9.45 7.0011,9.45 Z' /%3E %3Cpath id='m' d='M 0,0 H 16 V 12 H 0 Z' /%3E %3Cpath id='l' d='m 0,0 v -2 h -2 v 2 z m 16,0 h 2 v -2 h -2 z m 0,12 v 2 h 2 V 12 Z M 0,12 h -2 v 2 H 0 Z M 0,2 H 16 V -2 H 0 Z M 14,0 v 12 h 4 V 0 Z m 2,10 H 0 v 4 H 16 Z M 2,12 V 0 h -4 v 12 z' /%3E %3Cpath id='k' d='M 12,5.2941 H 8.5714 V 0 H 3.4285 V 5.2941 H -1e-4 l 6,6.1765 6,-6.1765 z M 0,13.2353 V 15 h 12 v -1.7647 z' /%3E %3Cpath id='j' d='M 9.3333,0 H 4.6666 V 1.5238 H 9.3333 Z M 6.2222,9.9048 H 7.7778 V 5.3334 H 6.2222 Z M 12.4678,4.8686 13.5722,3.7867 C 13.2378,3.39813 12.8722,3.03241 12.4756,2.7124 L 11.3711,3.7943 C 10.1656,2.84953 8.6489,2.2857 7,2.2857 3.1344,2.2857 0,5.3562 0,9.1429 0,12.9295 3.1267,16 7,16 10.8733,16 14,12.9295 14,9.1429 14,7.5277 13.4244,6.0419 12.4678,4.8686 Z M 7,14.4762 C 3.99,14.4762 1.5556,12.0914 1.5556,9.1429 1.5556,6.1943 3.99,3.8096 7,3.8096 c 3.01,0 5.4444,2.3848 5.4444,5.3333 0,2.9485 -2.4344,5.3333 -5.4444,5.3333 z' /%3E %3C/defs%3E %3Cg id='g3989' transform='matrix(0.03107656,0,0,0.03432918,271.52581,57.128037)' style='fill:%23ffffff'%3E %3Cg id='g3979' style='fill:%23ffffff'%3E %3Cpath style='fill:%23ffffff;stroke-width:0.03266241' d='m 273.49023,60.4375 c -1.07158,0 -1.96484,0.958273 -1.96484,2.169922 v 6.61914 c 0,1.216352 0.89727,2.167935 1.96484,2.167969 h 2.87305 c 0.52417,0 1.01765,-0.2246 1.39063,-0.634765 l 1,-1.103516 c 0.19059,-0.211639 0.45448,-0.333984 0.72656,-0.333984 0.27207,0 0.53829,0.122547 0.73047,0.335937 l 0.99804,1.101563 c 0.37212,0.409203 0.86646,0.634765 1.39063,0.634765 h 2.87305 c 1.07158,0 1.96484,-0.95632 1.96484,-2.167969 v -6.61914 c 0,-1.216352 -0.89727,-2.169922 -1.96484,-2.169922 z m 2.4961,3.308594 c 1.08295,0 1.96484,0.973618 1.96484,2.169922 0,1.196303 -0.88185,2.169921 -1.96484,2.169922 -1.08299,0 -1.96485,-0.973619 -1.96485,-2.169922 0,-1.196304 0.88189,-2.169922 1.96485,-2.169922 z m 6.99023,0 c 1.08296,0 1.96485,0.973618 1.96485,2.169922 0,1.196303 -0.88189,2.169922 -1.96485,2.169922 -1.08298,0 -1.96484,-0.973619 -1.96484,-2.169922 0,-1.196304 0.88189,-2.169922 1.96484,-2.169922 z' transform='matrix(32.178594,0,0,29.129737,-8737.3187,-1664.1247)' id='path3977' /%3E %3C/g%3E %3Cg id='g3983' style='fill:%23ffffff'/%3E %3Cg id='g3987' style='fill:%23ffffff'/%3E %3C/g%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 21.992188 A 6.9826789 6.9826789 0 0 0 310.04883 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 35.958984 A 6.9826789 6.9826789 0 0 0 324.01367 28.976562 A 6.9826789 6.9826789 0 0 0 317.03125 21.992188 z M 312.20703 27.580078 L 321.94336 27.642578 C 322.32865 27.645013 322.63647 27.956519 322.63281 28.341797 L 322.62109 29.603516 C 322.61743 29.988794 322.30326 30.297356 321.91797 30.294922 L 312.18164 30.232422 C 311.79635 30.229987 311.48853 29.918481 311.49219 29.533203 L 311.50391 28.271484 C 311.50757 27.886206 311.82174 27.577644 312.20703 27.580078 z ' id='path3997'/%3E %3Cpath style='fill:%23ffffff;fill-opacity:1' d='M 317.03125 59.992188 A 6.9826789 6.9826789 0 0 0 310.04883 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 73.958984 A 6.9826789 6.9826789 0 0 0 324.01367 66.976562 A 6.9826789 6.9826789 0 0 0 317.03125 59.992188 z M 316.49805 61.365234 L 317.76172 61.382812 C 318.14697 61.388692 318.45192 61.704576 318.44727 62.089844 L 318.4043 65.619141 L 321.94336 65.642578 C 322.32865 65.645013 322.63647 65.956519 322.63281 66.341797 L 322.62109 67.603516 C 322.61743 67.988794 322.30326 68.297356 321.91797 68.294922 L 318.37305 68.271484 L 318.33008 71.826172 C 318.32543 72.21144 318.0122 72.515645 317.62695 72.509766 L 316.36328 72.492188 C 315.97803 72.486309 315.67308 72.170424 315.67773 71.785156 L 315.7207 68.255859 L 312.18164 68.232422 C 311.79635 68.229987 311.48853 67.918481 311.49219 67.533203 L 311.50391 66.271484 C 311.50757 65.886206 311.82174 65.577644 312.20703 65.580078 L 315.75195 65.603516 L 315.79492 62.048828 C 315.79957 61.66356 316.1128 61.359355 316.49805 61.365234 z ' id='path3997-6'/%3E %3Cellipse style='fill:%23800000;fill-opacity:1;stroke-width:1.10310566' id='circle4073' cx='353.64172' cy='-28.97954' transform='scale(1,-1)' /%3E %3Cg id='g7787' transform='matrix(-0.02885349,0,0,-0.02885337,352.04486,75.172258)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cg id='g7731' transform='translate(-90.566882,42.049084)' style='fill:%23ffffff;fill-opacity:1'%3E %3Cpath id='path7729' d='M 242.607,0 C 108.629,0 0.001,108.628 0.001,242.606 c 0,133.976 108.628,242.606 242.606,242.606 133.978,0 242.604,-108.631 242.604,-242.606 C 485.212,108.628 376.585,0 242.607,0 Z M 401.815,288.094 H 219.862 v 90.979 L 83.397,242.606 219.862,106.141 v 90.978 h 181.953 z' style='fill:%23ffffff;fill-opacity:1'/%3E %3C/g%3E %3Cg id='g7733' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7735' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7737' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7739' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7741' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7743' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7745' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7747' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7749' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7751' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7753' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7755' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7757' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7759' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3Cg id='g7761' style='fill:%23ffffff;fill-opacity:1'%3E %3C/g%3E %3C/g%3E %3C/svg%3E") no-repeat;
+    float: left;
+    cursor: pointer;
+    height: 18px;
+    width: 18px;
+    background-position: -164px -21px;
+    opacity: 0;
+}
+
+.source_selected {
+    opacity: 1 !important;
+}
+
+.subtitle_selected {
+    opacity: 1 !important;
+}
+
+@media only screen and (min-device-width: 375px) {
+    .fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_fluid_control_duration {
+        left: 105px;
+    }
+
+    .fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container.no_volume_bar .fluid_fluid_control_duration {
+        left: 32px;
+    }
+
+    .fluid_video_wrapper.fluid_player_layout_default .fluid_controls_container .fluid_controls_right .fluid_control_volume_container {
+        display: block;
+    }
+}
+
+.fp_logo {
+    visibility: hidden;
+    opacity: 0;
+    -webkit-transition: visibility 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    -moz-transition: visibility 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    -ms-transition: visibility 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    -o-transition: visibility 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    transition: visibility 0.3s ease-in-out, opacity 0.3s ease-in-out;
+}
+
+.fp_hd_source::before {
+    font-weight: bolder;
+    font-size: 6pt;
+    content: 'HD';
+    padding-left: 3px;
+}

--- a/src/players/jwplayer/JWPlayer.js
+++ b/src/players/jwplayer/JWPlayer.js
@@ -1,0 +1,106 @@
+import GenericPlayer from '../GenericPlayer';
+import JWPlayerConfig from './JWPlayerConfig';
+import logger from '../../Logger';
+import utils from '../../Utils';
+
+export default class JWPlayer extends GenericPlayer{
+    constructor(){
+        super();
+        logger.debug("Inside JW player constructor.");
+        this.playerConfig = null;
+        this.player = null;
+        this.bid = null;
+        this.elementId = null;
+        this.element = null;
+        this.isVideoPlaying = false;
+    }
+
+    generatePlayerConfig(bid, elementId, genericConfiguration){
+        logger.debug("Inside JWPlayer.generatePlayerConfig");
+        this.bid = bid;
+
+        // Check if valid elementId
+        if(document.getElementById(elementId) === null){
+            logger.error("No element present with element ID: " + elementId);
+            throw new Error('Please provide a valid element ID.');
+        }
+
+        this.elementId = elementId;
+        this.element = document.getElementById(this.elementId);
+
+        this.genericConfiguration = genericConfiguration;
+        logger.log("JWPlayer configuration: ", JSON.stringify( this.genericConfiguration));
+
+        this.playerConfig = new JWPlayerConfig(this.bid, this.elementId, this.genericConfiguration);
+        logger.log("this.playerConfig: " + JSON.stringify(this.playerConfig));
+    }
+
+    setupPlayer(videoPlayerId){
+        logger.debug("Inside setupPlayer with player ID: ", videoPlayerId);
+
+        this.element.style.display = 'block';
+        if(document.getElementById(videoPlayerId) ===  null){
+            logger.error("No element is present with videoPlayerId: ", videoPlayerId);
+            throw new Error('Please provide a valid video player ID.');
+        }
+
+        document.getElementById(videoPlayerId).style.display = 'block';
+
+        // Embed script into DOM if it hasn't been run yet
+        if (!window.jwplayer) {
+            const script = document.createElement('script');
+            script.async = true;
+            script.src = "https://cdn.jwplayer.com/libraries/lqsWlr4Z.js";
+            script.onload = () => {
+                this.player = window.jwplayer(videoPlayerId).setup(this.playerConfig);
+                this.registerCallbacks();
+            }
+            document.body.appendChild(script);
+        } else if (window.jwplayer) {
+            this.player = window.jwplayer(videoPlayerId).setup(this.playerConfig);
+            this.registerCallbacks();
+        }
+    }
+
+    play(){
+        logger.debug("player play");
+        if (this.player) {
+            this.player.play();
+        }
+    }
+
+    pause(){
+        logger.debug("player pause");
+        if (this.player) {
+            this.player.pause();
+        }
+    }
+
+    registerCallbacks() {
+        this.player.on('pause', () => {
+            logger.log('Video is now paused.');
+            this.isVideoPlaying = false;
+        });
+
+        this.player.on('play', () => {
+            logger.log('Video is now playing - playing.');
+            this.isVideoPlaying = true;
+        });
+
+        this.player.on('complete', () => {
+            logger.log('Video is now ended.');
+            this.isVideoPlaying = false;
+            if(this.player) {
+                // Exit fullscreen mode
+                logger.log('Exit full screen mode to continue using normal mode.');
+                utils.closeFullscreen();
+            }
+        });
+    }
+
+    getIsVideoPlaying(){
+        logger.debug("Inside JWPlayer.getIsVideoPlaying. Returning the value: ", this.isVideoPlaying);
+        return this.isVideoPlaying;
+    }
+}
+

--- a/src/players/jwplayer/JWPlayerConfig.js
+++ b/src/players/jwplayer/JWPlayerConfig.js
@@ -6,7 +6,8 @@ export default class JWPlayerConfig{
         this.playlist = [{
             file: "https://d2zihajmogu5jn.cloudfront.net/tiny.mp4",
         }];
-        this.aspectratio = '16:9';
+
+        this.mute = genericConfiguration.mute;
         this.autostart = true;
         this.width = genericConfiguration.width;
         this.height = genericConfiguration.height;

--- a/src/players/jwplayer/JWPlayerConfig.js
+++ b/src/players/jwplayer/JWPlayerConfig.js
@@ -1,0 +1,51 @@
+import logger from '../../Logger';
+import merge from 'lodash.merge'
+
+export default class JWPlayerConfig{
+    constructor(bid, elementId, genericConfiguration){
+        this.playlist = [{
+            file: "https://d2zihajmogu5jn.cloudfront.net/tiny.mp4",
+        }];
+        this.aspectratio = '16:9';
+        this.autostart = true;
+        this.width = genericConfiguration.width;
+        this.height = genericConfiguration.height;
+        this.advertising = {
+            endstate :'close',
+            adscheduleid: 'sample01',
+            autoplayadsmuted: true,
+            client: 'vast',
+            schedule: {
+                'preroll': {
+                    "offset": "pre"
+                }
+            }
+        };
+
+        // Allow player config overrides
+        merge(this, genericConfiguration.playerOverrides);
+
+        let ad;
+        if( !(bid.ad === undefined || bid.ad === null) ){
+            logger.log("Bid object contains bid.ad with value: " + bid.ad);
+            ad = bid.ad;
+        }else if( !(bid.vastXml === undefined || bid.vastXml === null) ){
+            logger.log("Bid object contains bid.vastXml with value: " + bid.vastXml);
+            ad = bid.vastXml;
+        }
+
+        if (ad) {
+            if (ad.search(/<VAST/ig) !== -1) {
+                // No direct support for VAST tag, so creating a Data URI
+                logger.log("VAST type creative: " + ad);
+                logger.log("VAST type creativrr base 64: " + btoa(ad.replace(/\\"/g, "\"")));
+                this.advertising.schedule.preroll.vastxml = ad;
+            } else if (ad.startsWith('http')) {
+                logger.log("Ad tag type creativrr: " + ad);
+                this.advertising.schedule.preroll.tag = ad;
+            }
+        } else {
+            logger.error("Bid object doesn't contain bid.ad or bid.vastXml object, so no VAST tag or XML is available.");
+        }
+    }
+}

--- a/src/players/videojs/VideoJs.js
+++ b/src/players/videojs/VideoJs.js
@@ -53,15 +53,15 @@ export default class VideoJs extends GenericPlayer{
 
         const video = document.getElementById(videoPlayerId);
 
-        video.className += ' video-js';
-        logger.log("adding videojs to element", videoPlayerId, this.element.className);
+        video.className += ' video-js vjs-big-play-centered';
 
         this.player = videojs(videoPlayerId, this.playerConfig);
-        this.player.src("//d2zihajmogu5jn.cloudfront.net/tiny.mp4");
-        this.player.on('error', e => console.log('vjs error:', e));
+        this.player.src("https://d2zihajmogu5jn.cloudfront.net/tiny.mp4");
+        this.player.on('error', e => console.log('vjs error:', e, this.player.error()));
         this.player.on('vast.adError', e => console.log('vjs ad error:', e));
         this.player.on(["adFinished", "vast.contentStart"], () => {
-            this.player.pause(); // don't play the video ever
+            // don't play the video ever
+            this.player.pause();
             this.player.dispose();
         });
     }

--- a/src/players/videojs/VideoJs.js
+++ b/src/players/videojs/VideoJs.js
@@ -1,33 +1,83 @@
+import videojs from 'video.js';
+
+// Manually load in window.videojs
+window.videojs = videojs;
+// Use require to force vast plugin to load in after video.js
+require('@prebid/videojs-vast/bin/videojs_5.vast.vpaid');
+import 'video.js/dist/video-js.css';
+
 import GenericPlayer from '../GenericPlayer';
 import logger from '../../Logger';
-
+import VideoJsConfig from './VideoJsConfig';
 
 export default class VideoJs extends GenericPlayer{
     constructor(){
         super();
         logger.debug("Inside videojs player constructor.");
+        logger.log("Player object: ", videojs);
+        this.playerConfig = null;
+        this.player = null;
+        this.bid = null;
+        this.elementId = null;
+        this.element = null;
+        this.isVideoPlaying = false;
     }
 
     generatePlayerConfig(bid, elementId, genericConfiguration){
-        logger.debug("Inside VideoJs.generatePlayerConfig method.");
+        logger.debug("Inside generatePlayerConfig");
         this.bid = bid;
+
+        // Check if valid elementId
+        if(document.getElementById(elementId) === null){
+            logger.error("No element present with element ID: " + elementId);
+            throw new Error('Please provide a valid element ID.');
+        }
+
         this.elementId = elementId;
+        this.element = document.getElementById(this.elementId);
+
         this.genericConfiguration = genericConfiguration;
+        logger.log("configuration: ", JSON.stringify( this.genericConfiguration));
+
+        this.playerConfig = new VideoJsConfig(this.bid, this.elementId, this.genericConfiguration);
+        logger.log("this.playerConfig: " + JSON.stringify(this.playerConfig));
     }
 
     setupPlayer(videoPlayerId){
-        logger.debug("Inside VideoJs.generatePlayerConfig method with player ID: " + videoPlayerId);
+        logger.debug("Inside setupPlayer with player ID: ", videoPlayerId);
+
+        if(document.getElementById(videoPlayerId) ===  null){
+            logger.error("No element is present with videoPlayerId: ", videoPlayerId);
+            throw new Error('Please provide a valid video player ID.');
+        }
+
+        const video = document.getElementById(videoPlayerId);
+
+        video.className += ' video-js';
+        logger.log("adding videojs to element", videoPlayerId, this.element.className);
+
+        this.player = videojs(videoPlayerId, this.playerConfig);
+        this.player.src("//d2zihajmogu5jn.cloudfront.net/tiny.mp4");
+        this.player.on('error', e => console.log('vjs error:', e));
+        this.player.on('vast.adError', e => console.log('vjs ad error:', e));
+        this.player.on(["adFinished", "vast.contentStart"], () => {
+            this.player.pause(); // don't play the video ever
+            this.player.dispose();
+        });
     }
 
     play(){
-        logger.debug("Inside VideoJs.play");
+        logger.debug("player play");
+        this.player.play();
     }
 
     pause(){
-        logger.debug("Inside VideoJs.pause");
+        logger.debug("player pause");
+        this.player.pause();
     }
 
     getIsVideoPlaying(){
-        logger.debug("Inside VideoJs.getIsVideoPlaying");
+        logger.debug("player getIsVideoPlaying. Returning the value: ", this.isVideoPlaying);
+        return this.isVideoPlaying;
     }
 }

--- a/src/players/videojs/VideoJsConfig.js
+++ b/src/players/videojs/VideoJsConfig.js
@@ -1,0 +1,47 @@
+import logger from '../../Logger';
+import merge from 'lodash.merge'
+
+export default class VideoJsConfig{
+    constructor(bid, elementId, genericConfiguration){
+        videojs.log.level('debug');
+        this.controls = true;
+        this.autoplay = true;
+        this.preload = 'none';
+        this.height = genericConfiguration.height;
+        this.width = genericConfiguration.width;
+        this.muted = genericConfiguration.mute;
+        this.plugins = {
+            vastClient: {
+                adsEnabled: true,
+                playAdAlways: true,
+                verbosity: 4,
+                initialAudio: 'off',
+            }
+        };
+
+        // Allow player config overrides
+        merge(this, genericConfiguration.playerOverrides);
+
+        let ad;
+        if( !(bid.ad === undefined || bid.ad === null) ){
+            logger.log("Bid object contains bid.ad with value: " + bid.ad);
+            ad = bid.ad;
+        }else if( !(bid.vastXml === undefined || bid.vastXml === null) ){
+            logger.log("Bid object contains bid.vastXml with value: " + bid.vastXml);
+            ad = bid.vastXml;
+        }
+
+        if (ad) {
+            if (ad.search(/<VAST/ig) !== -1) {
+                // No direct support for VAST tag, so creating a Data URI
+                logger.log("VAST type creative: " + ad);
+                this.plugins.vastClient.adTagXML = callback => callback(null, ad);
+            } else if (ad.startsWith('http')) {
+                logger.log("Ad tag type creativrr: " + ad);
+                this.plugins.vastClient.adTagUrl = ad;
+            }
+        } else {
+            logger.error("Bid object doesn't contain bid.ad or bid.vastXml object, so no VAST tag or XML is available.");
+        }
+    }
+}

--- a/src/players/videojs/VideoJsConfig.js
+++ b/src/players/videojs/VideoJsConfig.js
@@ -5,7 +5,6 @@ export default class VideoJsConfig{
     constructor(bid, elementId, genericConfiguration){
         videojs.log.level('debug');
         this.controls = true;
-        this.autoplay = true;
         this.preload = 'none';
         this.height = genericConfiguration.height;
         this.width = genericConfiguration.width;
@@ -14,7 +13,6 @@ export default class VideoJsConfig{
             vastClient: {
                 adsEnabled: true,
                 playAdAlways: true,
-                verbosity: 4,
                 initialAudio: 'off',
             }
         };


### PR DESCRIPTION
There are a few things here, I was able to:
- Add player override feature. This was necessary so that you can set primary colors for fluid player. Also to override player configs as needed.
- Update fluid player style. Fluid player css was updated and it looks closer to the demo player:
![image](https://user-images.githubusercontent.com/5578150/114797572-4f629900-9d48-11eb-98bd-844ff51ae322.png)
- Update videojs implementation. POC for video js vast consumption:
![image](https://user-images.githubusercontent.com/5578150/114797388-eda22f00-9d47-11eb-86fa-d10023710c62.png)
- Add jwplayer implementation. POC for jwplayer vast consumption:
![image](https://user-images.githubusercontent.com/5578150/114797292-b29ffb80-9d47-11eb-9489-46349c49fdd4.png)
