### PR TITLE
Fixes for TypeScript and for reading vast from adResponse

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -46,7 +46,7 @@ class Logger {
 
     error = (msg: string, args?: any) => {
         if (this.logLevel >= LogLevel.error) {
-            console.error(this.prefixMessage('ERROR', msg));
+            console.error(this.prefixMessage('ERROR', msg), args);
         }
     };
 

--- a/src/OutstreamPlayer.ts
+++ b/src/OutstreamPlayer.ts
@@ -58,12 +58,13 @@ export default class OutstreamPlayer {
         this.isVideoPausedDueToScroll = false;
         this.player = getConfiguredPlayer();
         logger.log(`Player object: ${JSON.stringify(this.player)}`);
+        const outerThis = this;
 
         if (this.bid.hasOwnProperty('vastUrl') && this.bid.vastUrl && !this.bid.hasOwnProperty('vastXml') && !this.bid.hasOwnProperty('ad')) {
             logger.warn('Bid lacking vastXml and ad properties but included vastUrl. Trying to fetch vastXml from vastUrl.', this.bid);
             this.fetchVastXml(this.bid.vastUrl, function () {
-                this.player.generatePlayerConfig(this.bid, this.elementId, this.config);
-                this.insertPlayer();
+                outerThis.player.generatePlayerConfig(outerThis.bid, outerThis.elementId, outerThis.config);
+                outerThis.insertPlayer();
             });
         } else {
             this.player.generatePlayerConfig(this.bid, this.elementId, this.config);
@@ -180,7 +181,7 @@ export default class OutstreamPlayer {
         xhr.overrideMimeType('text/xml');
         xhr.onload = () => {
             if (xhr.readyState === xhr.DONE) {
-                if (xhr.status === 200) {
+                if (xhr.status === 200 && xhr.responseXML) {
                     logger.log('OutstreamPlayer.fetchVastXml: Received XML response', xhr.responseXML.documentElement);
                     const serializer = new XMLSerializer();
                     this.bid.vastXml = serializer.serializeToString(xhr.responseXML.documentElement);

--- a/src/players/fluid-player/FluidPlayerConfig.ts
+++ b/src/players/fluid-player/FluidPlayerConfig.ts
@@ -58,6 +58,14 @@ export const fluidPlayerConfig = (
                 }
             }
         },
+        captions: {
+            play: 'Play',
+            pause: 'Pause',
+            mute: 'Mute',
+            unmute: 'Unmute',
+            fullscreen: 'Fullscreen',
+            exitFullscreen: 'Exit Fullscreen'
+        },
         layoutControls: {
             playButtonShowing: true,
             autoPlay: false,
@@ -68,14 +76,6 @@ export const fluidPlayerConfig = (
                 autoHide: true,
                 autoHideTimeout: 5,
                 animated: true
-            },
-            captions: {
-                play: 'Play',
-                pause: 'Pause',
-                mute: 'Mute',
-                unmute: 'Unmute',
-                fullscreen: 'Fullscreen',
-                exitFullscreen: 'Exit Fullscreen'
             },
             controlForwardBackward: {
                 show: false
@@ -128,7 +128,10 @@ export const fluidPlayerConfig = (
 
     // Make this immutability one day
     let ad;
-    if (!(bid.ad === undefined || bid.ad === null)) {
+    if (bid.adResponse?.ads && bid.adResponse?.ads[0]?.video?.content !== undefined) {
+        logger.log('Bid object contains bid.adResponse: ' + bid.ad);
+        ad = bid.adResponse.ads[0].video.content;
+    } else if (!(bid.ad === undefined || bid.ad === null)) {
         logger.log('Bid object contains bid.ad with value: ' + bid.ad);
         ad = bid.ad;
     } else if (!(bid.vastXml === undefined || bid.vastXml === null)) {

--- a/src/types/bid.ts
+++ b/src/types/bid.ts
@@ -1,5 +1,12 @@
 export type Bid = Partial<{
     ad: string | null;
+    adResponse: {
+        ads: {
+            video: {
+                content: string | null
+            } | null
+        }[] | null
+    } | null;
     vastXml: string;
 
     /**

--- a/src/types/fluid-player.d.ts
+++ b/src/types/fluid-player.d.ts
@@ -43,6 +43,14 @@ declare module 'fluid-player' {
                 vastVideoEndedCallback: () => void;
             };
         };
+        captions: {
+            play: string;
+            pause: string;
+            mute: string;
+            unmute: string;
+            fullscreen: string;
+            exitFullscreen: string;
+        };
         layoutControls: {
             playButtonShowing: boolean;
             autoPlay: boolean;
@@ -62,14 +70,6 @@ declare module 'fluid-player' {
                  * Default true
                  */
                 animated: boolean;
-            };
-            captions: {
-                play: string;
-                pause: string;
-                mute: string;
-                unmute: string;
-                fullscreen: string;
-                exitFullscreen: string;
             };
             controlForwardBackward: {
                 /**

--- a/test/Logger.test.ts
+++ b/test/Logger.test.ts
@@ -8,7 +8,7 @@ describe('Test cases for Logger.js file', () => {
             let result = logger.log('Test message.');
             expect(result).toBeUndefined();
             expect(console.log).toHaveBeenCalledTimes(1);
-            expect(console.log).toHaveBeenNthCalledWith(1, 'PLAYER-LOG: Test message.');
+            expect(console.log).toHaveBeenNthCalledWith(1, 'PLAYER-LOG: Test message.', undefined);
 
             consoleLogMock.mockReset();
         });
@@ -34,7 +34,7 @@ describe('Test cases for Logger.js file', () => {
             let result = logger.warn('Test message.');
             expect(result).toBeUndefined();
             expect(console.warn).toHaveBeenCalledTimes(1);
-            expect(console.warn).toHaveBeenNthCalledWith(1, 'PLAYER-WARN: Test message.');
+            expect(console.warn).toHaveBeenNthCalledWith(1, 'PLAYER-WARN: Test message.', undefined);
 
             consoleWarnMock.mockReset();
         });
@@ -47,7 +47,7 @@ describe('Test cases for Logger.js file', () => {
             let result = logger.error('Test message.');
             expect(result).toBeUndefined();
             expect(console.error).toHaveBeenCalledTimes(1);
-            expect(console.error).toHaveBeenNthCalledWith(1, 'PLAYER-ERROR: Test message.');
+            expect(console.error).toHaveBeenNthCalledWith(1, 'PLAYER-ERROR: Test message.', undefined);
 
             consoleErrorMock.mockReset();
         });

--- a/test/players/fluid-player/FluidPlayerConfig.test.ts
+++ b/test/players/fluid-player/FluidPlayerConfig.test.ts
@@ -60,6 +60,24 @@ describe('Test cases for players/fluid-player/FluidPlayerConfig.js file', () => 
         expect(obj.vastOptions.adList[0].vastTag).toEqual(base64String);
     });
 
+    test('it should assign VAST Tag from bid.adResponse.ads[0].video.content if available', () => {
+        const vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=';
+        let bid = {
+            adResponse: {
+                ads: [
+                    {
+                        video: {
+                            content: vastTag
+                        }
+                    }
+                ]
+            }
+        };
+
+        let obj = fluidPlayerConfig(bid, elementId, genericConfiguration);
+        expect(obj.vastOptions.adList[0].vastTag).toEqual(vastTag);
+    });
+
     test('it should assign VAST Tag', () => {
         let bid = {
             ad:


### PR DESCRIPTION
Made some changes to make code compile again
Fixed incompatibly with recent versions of Fluid video player
Fixed incompatibly with how Prebid passed video response